### PR TITLE
Update references to old repo.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       name: Cache ~/.stack
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-${{ matrix.ghc }}-v6
+        key: ${{ runner.os }}-${{ matrix.ghc }}-v7
 
     - name: Add ~/.local/bin to PATH
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/README.markdown
+++ b/README.markdown
@@ -37,7 +37,7 @@ You can also install it using your package manager:
 
 Feature requests are welcome! Use the [issue tracker] for that.
 
-[issue tracker]: https://github.com/jaspervdj/stylish-haskell/issues
+[issue tracker]: https://github.com/haskell/stylish-haskell/issues
 
 ## Example
 
@@ -234,7 +234,7 @@ haskell-mode manual.
 
 You can quickly grab the latest binary and run `stylish-haskell` like so:
 
-    curl -sL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh | sh -s .
+    curl -sL https://raw.github.com/haskell/stylish-haskell/master/scripts/latest.sh | sh -s .
 
 Where the `.` can be replaced with the arguments you pass to `stylish-haskell`.
 

--- a/scripts/latest.sh
+++ b/scripts/latest.sh
@@ -6,7 +6,7 @@ set -e
 PACKAGE=stylish-haskell
 echo Downloading and running $PACKAGE...
 
-RELEASES=$(curl --silent https://github.com/jaspervdj/$PACKAGE/releases)
+RELEASES=$(curl --silent https://github.com/haskell/$PACKAGE/releases)
 URL=https://github.com/$(echo $RELEASES | grep -o '\"[^\"]*-linux-x86_64\.tar\.gz\"' | sed s/\"//g | head -n1)
 VERSION=$(echo $URL | sed -e 's/.*-\(v[\.0-9]\+-linux-x86_64\)\.tar\.gz/\1/')
 TEMP=$(mktemp --directory .$PACKAGE-XXXXX)

--- a/scripts/stylish-haskell.sh
+++ b/scripts/stylish-haskell.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Ported from https://github.com/ndmitchell/hlint/blob/master/misc/travis.sh
 
-curl -sL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh | sh -s -- stylish-haskell $*
+curl -sL https://raw.github.com/haskell/stylish-haskell/master/scripts/latest.sh | sh -s -- stylish-haskell $*

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -2,7 +2,7 @@ Cabal-version: 2.4
 Name:          stylish-haskell
 Version:       0.12.2.0
 Synopsis:      Haskell code prettifier
-Homepage:      https://github.com/jaspervdj/stylish-haskell
+Homepage:      https://github.com/haskell/stylish-haskell
 License:       BSD-3-Clause
 License-file:  LICENSE
 Author:        Jasper Van der Jeugt <m@jaspervdj.be>
@@ -16,7 +16,7 @@ Description:
 
     .
 
-    <https://github.com/jaspervdj/stylish-haskell/blob/master/README.markdown>
+    <https://github.com/haskell/stylish-haskell/blob/master/README.markdown>
 
 Extra-source-files:
   CHANGELOG,
@@ -179,4 +179,4 @@ Test-suite stylish-haskell-tests
 
 Source-repository head
   Type:     git
-  Location: https://github.com/jaspervdj/stylish-haskell
+  Location: https://github.com/haskell/stylish-haskell

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -450,7 +450,7 @@ case19 = expected @=? testStep (step indentIndentStyle) input
 
 -- | Should not break Enums (data without records) formatting
 --
--- See https://github.com/jaspervdj/stylish-haskell/issues/262
+-- See https://github.com/haskell/stylish-haskell/issues/262
 case20 :: Assertion
 case20 = input @=? testStep (step indentIndentStyle) input
   where
@@ -1277,7 +1277,7 @@ case57 = assertSnippet (step defaultConfig)
 
 -- | Should not break DataKinds in records
 --
--- See https://github.com/jaspervdj/stylish-haskell/issues/330
+-- See https://github.com/haskell/stylish-haskell/issues/330
 case58 :: Assertion
 case58 = expected @=? testStep (step sameIndentStyle) input
   where

--- a/tests/Language/Haskell/Stylish/Step/Imports/FelixTests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/FelixTests.hs
@@ -1,15 +1,16 @@
 -- | Tests contributed by Felix Mulder as part of
--- <https://github.com/jaspervdj/stylish-haskell/pull/293>.
+-- <https://github.com/haskell/stylish-haskell/pull/293>.
 module Language.Haskell.Stylish.Step.Imports.FelixTests
   ( tests
   ) where
 
 --------------------------------------------------------------------------------
+import           GHC.Stack                             (HasCallStack,
+                                                        withFrozenCallStack)
+import           Prelude                               hiding (lines)
 import           Test.Framework                        (Test, testGroup)
 import           Test.Framework.Providers.HUnit        (testCase)
 import           Test.HUnit                            (Assertion)
-import           GHC.Stack                             (HasCallStack, withFrozenCallStack)
-import           Prelude                               hiding (lines)
 
 --------------------------------------------------------------------------------
 import           Language.Haskell.Stylish.Module


### PR DESCRIPTION
This small PR updates all links to the old repo to this one, mostly so that the scripts can work again.

I left the link to the build icon untouched, just to be safe, but I can include it if required.

The code change is only the result of running stylish-haskell on the file when saving it. :)