### PR TITLE
Fix Nix build, bumping haskell.nix (#397)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,26 @@
 { pkgs ? import ./haskell-pkgs.nix
-, haskellCompiler ? "ghc8104"
+, haskellCompiler ? "ghc8107"
 }:
 pkgs.haskell-nix.cabalProject {
   src = pkgs.haskell-nix.haskellLib.cleanGit {
     name = "stylish-haskell";
     src = ./.;
   };
+
   compiler-nix-name = haskellCompiler;
+
+  # need to make Cabal reinstallable, otherwise Haskell.nix uses the
+  # version of Cabal that ships with the compiler even when that would
+  # violate the constraint in stylish-haskell.cabal
+  #
+  # (eg nix-build failed because it tried to use Cabal-3.2.1.0 while
+  # stylish-haskell needs Cabal >= 3.4 && < 3.7)
+  #
+  # See haskell-nix issue #1337 for details:
+  # https://github.com/input-output-hk/haskell.nix/issues/1337
+  modules = [
+    ({ lib, ... }: {
+      options.nonReinstallablePkgs = lib.mkOption { apply = lib.remove "Cabal"; };
+    })
+  ];
 }

--- a/haskell-pkgs.nix
+++ b/haskell-pkgs.nix
@@ -2,14 +2,14 @@ let
   # Fetch the latest haskell.nix and import its default.nix
   haskellNix = import
     (builtins.fetchTarball {
-      url = "https://github.com/input-output-hk/haskell.nix/archive/1b9b05beed75a1be98405501fbb33ac1f080069e.tar.gz";
+      url = "https://github.com/input-output-hk/haskell.nix/archive/cc40a24585ccba274dc9a5af96d5506034e0d658.tar.gz";
     })
     { };
 
   # haskell.nix provides access to the nixpkgs pins which are used by our CI,
   # hence you will be more likely to get cache hits when using these.
   # But you can also just use your own, e.g. '<nixpkgs>'.
-  nixpkgsSrc = haskellNix.sources.nixpkgs-2009;
+  nixpkgsSrc = haskellNix.sources.nixpkgs-2111;
 
   # haskell.nix provides some arguments to be passed to nixpkgs, including some
   # patches and also the haskell.nix functionality itself as an overlay.

--- a/shell.nix
+++ b/shell.nix
@@ -14,9 +14,8 @@ hsPkgs.shellFor {
   # You might want some extra tools in the shell (optional).
   # Some common tools can be added with the `tools` argument
   tools = {
-    cabal = "3.2.0.0";
-    hlint = "2.2.11";
-    stylish-haskell = "0.12.2.0";
+    cabal = "3.6.2.0";
+    hlint = "3.3.6";
   };
   # See overlays/tools.nix for more details
 
@@ -24,6 +23,8 @@ hsPkgs.shellFor {
   buildInputs = [
     pkgs.ghcid
     pkgs.nixpkgs-fmt
+    pkgs.stylish-haskell
+    pkgs.haskell-language-server
   ];
 
   # Prevents cabal from choosing alternate plans, so that


### PR DESCRIPTION
Fixes `nix-shell` and `nix-build` for the repo, which was failing with a dependency error (#397).

This PR takes two steps to fix this:

  1. It bumps the version of `haskell.nix` we use, switching to GHC 8.10.7 and Nixpkgs 21.11 so that we still use the haskell.nix cache

  2. After 1., I ran into an error where haskell.nix was using Cabal-3.2.1.0 even though `stylish-haskell.cabal` needs Cabal >= 3.4. To fix this, I had to explicitly mark the Cabal library as "reinstallable"—otherwise, haskell.nix uses the exact version that comes with GHC. (See [haskell-nix issue #1337][1] for details.)

[1]: https://github.com/input-output-hk/haskell.nix/issues/1337

I tested this change locally. Both `nix-build` and `nix-shell` succeeded without needing to build GHC from source.