### PR TITLE
Option to group imports automatically

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -294,6 +294,107 @@ steps:
       # Default: false
       post_qualify: false
 
+      # Automatically group imports based on their module names, with
+      # a blank line separating each group. Groups are ordered in
+      # alphabetical order.
+      #
+      # By default, this groups by the first part of each module's
+      # name (Control.* will be grouped together, Data.*... etc), but
+      # this can be configured with the group_patterns setting.
+      #
+      # When enabled, this rewrites existing blank lines and groups.
+      #
+      # - true: Group imports by the first part of the module name.
+      #
+      #   > import Control.Applicative
+      #   > import Control.Monad
+      #   > import Control.Monad.MonadError
+      #   >
+      #   > import Data.Functor
+      #
+      # - false: Keep import groups as-is (still sorting and
+      #   formatting the imports within each group)
+      #
+      #   > import Control.Monad
+      #   > import Data.Functor
+      #   >
+      #   > import Control.Applicative
+      #   > import Control.Monad.MonadError
+      #
+      # Default: false
+      group_imports: false
+
+      # A list of rules specifying how to group modules and how to
+      # order the groups.
+      #
+      # Each rule has a match field; the rule only applies to module
+      # names matched by this pattern. Patterns are POSIX extended
+      # regular expressions; see the documentation of Text.Regex.TDFA
+      # for details:
+      # https://hackage.haskell.org/package/regex-tdfa-1.3.1.2/docs/Text-Regex-TDFA.html
+      #
+      # Rules are processed in order, so only the *first* rule that
+      # matches a specific module will apply. Any module names that do
+      # not match a single rule will be put into a single group at the
+      # end of the import block.
+      #
+      # Example: group MyApp modules first, with everything else in
+      # one group at the end.
+      #
+      #  group_rules:
+      #    - match: "^MyApp\\>"
+      #
+      #  > import MyApp
+      #  > import MyApp.Foo
+      #  >
+      #  > import Control.Monad
+      #  > import MyApps
+      #  > import Test.MyApp
+      #
+      # A rule can also optionally have a sub_group pattern. Imports
+      # that match the rule will be broken up into further groups by
+      # the part of the module name matched by the sub_group pattern.
+      #
+      # Example: group MyApp modules first, then everything else
+      # sub-grouped by the first part of the module name.
+      #
+      #  group_rules:
+      #    - match: "^MyApp\\>"
+      #    - match: "."
+      #      sub_group: "^[^.]+"
+      #
+      #  > import MyApp
+      #  > import MyApp.Foo
+      #  >
+      #  > import Control.Applicative
+      #  > import Control.Monad
+      #  >
+      #  > import Data.Map
+      #
+      # A pattern only needs to match part of the module name, which
+      # could be in the middle. You can use ^pattern to anchor to the
+      # beginning of the module name, pattern$ to anchor to the end
+      # and ^pattern$ to force a full match. Example:
+      #
+      #  - "Test\\." would match "Test.Foo" and "Foo.Test.Lib"
+      #  - "^Test\\." would match "Test.Foo" but not "Foo.Test.Lib"
+      #  - "\\.Test$" would match "Foo.Test" but not "Foo.Test.Lib"
+      #  - "^Test$" would *only* match "Test"
+      #
+      # You can use \\< and \\> to anchor against the beginning and
+      # end of words, respectively. For example:
+      #
+      #  - "^Test\\." would match "Test.Foo" but not "Test" or "Tests"
+      #  - "^Test\\>" would match "Test.Foo" and "Test", but not
+      #    "Tests"
+      #
+      # The default is a single rule that matches everything and
+      # sub-groups based on the first component of the module name.
+      #
+      # Default: [{ "match" : ".*", "sub_group": "^[^.]+" }]
+      group_rules:
+        - match: ".*"
+          sub_group: "^[^.]+"
 
   # Language pragmas
   - language_pragmas:

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -287,6 +287,8 @@ parseImports config o = fmap (Imports.step columns) $ Imports.Options
       <*> o A..:? "separate_lists" A..!= def Imports.separateLists
       <*> o A..:? "space_surround" A..!= def Imports.spaceSurround
       <*> o A..:? "post_qualify" A..!= def Imports.postQualified
+      <*> o A..:? "group_imports" A..!= def Imports.groupImports
+      <*> o A..:? "group_rules" A..!= def Imports.groupRules
   where
     def f = f Imports.defaultOptions
 

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -43,6 +43,7 @@ Common depends
     filepath          >= 1.1    && < 1.5,
     file-embed        >= 0.0.10 && < 0.1,
     mtl               >= 2.0    && < 2.3,
+    regex-tdfa        >= 1.3    && < 1.4,
     syb               >= 0.3    && < 0.8,
     text              >= 1.2    && < 1.3,
     HsYAML-aeson      >=0.2.0   && < 0.3,

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -1,5 +1,6 @@
+{-# LANGUAGE OverloadedStrings #-}
 --------------------------------------------------------------------------------
-{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedLists   #-}
 module Language.Haskell.Stylish.Step.Imports.Tests
     ( tests
     ) where
@@ -70,6 +71,14 @@ tests = testGroup "Language.Haskell.Stylish.Step.Imports.Tests"
     , testCase "case 36" case36
     , testCase "case 37" case37
     , testCase "case 38" case38
+    , testCase "case 39" case39
+    , testCase "case 40" case40
+    , testCase "case 41" case41
+    , testCase "case 42" case42
+    , testCase "case 43" case43
+    , testCase "case 44a" case44a
+    , testCase "case 44b" case44b
+    , testCase "case 44c" case44c
     ]
 
 
@@ -198,7 +207,7 @@ case07 = assertSnippet (step (Just 80) $ fromImportAlign File)
 case08 :: Assertion
 case08 =
   let
-    options = Options Global WithAlias True Inline Inherit (LPConstant 4) True False False
+    options = defaultOptions { listAlign = WithAlias }
   in
     assertSnippet (step (Just 80) options) input
     [ "module Herp where"
@@ -222,7 +231,7 @@ case08 =
 case08b :: Assertion
 case08b =
   let
-    options = Options Global WithModuleName True Inline Inherit (LPConstant 4) True False False
+    options = defaultOptions { listAlign = WithModuleName }
   in
     assertSnippet (step (Just 80) options) input
     ["module Herp where"
@@ -245,7 +254,7 @@ case08b =
 case09 :: Assertion
 case09 =
   let
-    options = Options Global WithAlias True Multiline Inherit (LPConstant 4) True False False
+    options = defaultOptions { listAlign = WithAlias, longListAlign = Multiline }
   in
     assertSnippet (step (Just 80) options) input
     [ "module Herp where"
@@ -280,7 +289,11 @@ case09 =
 case10 :: Assertion
 case10 =
   let
-    options = Options Group WithAlias True Multiline Inherit (LPConstant 4) True False False
+    options = defaultOptions
+      { importAlign   = Group
+      , listAlign     = WithAlias
+      , longListAlign = Multiline
+      }
   in
     assertSnippet (step (Just 40) options) input
     [ "module Herp where"
@@ -321,7 +334,7 @@ case10 =
 case11 :: Assertion
 case11 =
   let
-    options = Options Group NewLine True Inline Inherit (LPConstant 4) True False False
+    options = defaultOptions { importAlign = Group, listAlign = NewLine }
   in
     assertSnippet (step (Just 80) options) input
     [ "module Herp where"
@@ -348,7 +361,7 @@ case11 =
 case11b :: Assertion
 case11b =
   let
-    options = Options Group WithModuleName True Inline Inherit (LPConstant 4) True False False
+    options = defaultOptions { importAlign = Group, listAlign = WithModuleName }
   in
     assertSnippet (step (Just 80) options) input
     [ "module Herp where"
@@ -371,7 +384,11 @@ case11b =
 case12 :: Assertion
 case12 =
   let
-    options = Options Group NewLine True Inline Inherit (LPConstant 2) True False False
+    options = defaultOptions
+      { importAlign = Group
+      , listAlign   = NewLine
+      , listPadding = LPConstant 2
+      }
   in
     assertSnippet (step (Just 80) options)
     [ "import Data.List (map)"
@@ -385,7 +402,11 @@ case12 =
 case12b :: Assertion
 case12b =
   let
-    options = Options Group WithModuleName True Inline Inherit (LPConstant 2) True False False
+    options = defaultOptions
+      { importAlign = Group
+      , listAlign   = WithModuleName
+      , listPadding = LPConstant 2
+      }
   in
     assertSnippet (step (Just 80) options)
     ["import Data.List (map)"]
@@ -396,7 +417,11 @@ case12b =
 case13 :: Assertion
 case13 =
   let
-    options = Options None WithAlias True InlineWithBreak Inherit (LPConstant 4) True False False
+    options = defaultOptions
+      { importAlign   = None
+      , listAlign     = WithAlias
+      , longListAlign = InlineWithBreak
+      }
   in
     assertSnippet (step (Just 80) options)
     [ "import qualified Data.List as List (concat, foldl, foldr, head, init,"
@@ -410,7 +435,11 @@ case13 =
 case13b :: Assertion
 case13b =
   let
-    options = Options None WithModuleName True InlineWithBreak Inherit (LPConstant 4) True False False
+    options = defaultOptions
+      { importAlign   = None
+      , listAlign     = WithModuleName
+      , longListAlign = InlineWithBreak
+      }
   in
     assertSnippet (step (Just 80) options)
     [ "import qualified Data.List as List (concat, foldl, foldr, head, init,"
@@ -426,7 +455,12 @@ case13b =
 case14 :: Assertion
 case14 =
   let
-    options = Options None WithAlias True InlineWithBreak Inherit (LPConstant 10) True False False
+    options = defaultOptions
+      { importAlign   = None
+      , listAlign     = WithAlias
+      , longListAlign = InlineWithBreak
+      , listPadding   = LPConstant 10
+      }
   in
     assertSnippet (step (Just 80) options)
     [ "import qualified Data.List as List (concat, map, null, reverse, tail, (++))"
@@ -439,7 +473,7 @@ case14 =
 case15 :: Assertion
 case15 =
   let
-    options = Options None AfterAlias True Multiline Inherit (LPConstant 4) True False False
+    options = defaultOptions { importAlign = None, longListAlign = Multiline }
   in
     assertSnippet (step (Just 80) options)
     [ "import Data.Acid (AcidState)"
@@ -464,7 +498,11 @@ case15 =
 case16 :: Assertion
 case16 =
   let
-    options = Options None AfterAlias True Multiline Inherit (LPConstant 4) False False False
+    options = defaultOptions
+      { importAlign   = None
+      , longListAlign = Multiline
+      , separateLists = False
+      }
   in
     assertSnippet (step (Just 80) options)
     [ "import Data.Acid (AcidState)"
@@ -487,7 +525,7 @@ case16 =
 case17 :: Assertion
 case17 =
   let
-    options = Options None AfterAlias True Multiline Inherit (LPConstant 4) True False False
+    options = defaultOptions { importAlign = None, longListAlign = Multiline }
   in
     assertSnippet (step (Just 80) options)
     [ "import Control.Applicative (Applicative ((<*>),pure))"
@@ -504,7 +542,7 @@ case17 =
 case18 :: Assertion
 case18 =
   let
-    options = Options None AfterAlias True InlineToMultiline Inherit (LPConstant 4) True False False
+    options = defaultOptions { importAlign = None, longListAlign = InlineToMultiline }
   in
     assertSnippet (step (Just 40) options)
     [ "import Data.Foo as Foo (Bar, Baz, Foo)"
@@ -531,7 +569,12 @@ case18 =
 case19 :: Assertion
 case19 =
   let
-    options = Options Global NewLine True InlineWithBreak RightAfter (LPConstant 17) True False False
+    options = defaultOptions
+      { listAlign      = NewLine
+      , longListAlign  = InlineWithBreak
+      , emptyListAlign = RightAfter
+      , listPadding    = LPConstant 17
+      }
   in
     assertSnippet (step (Just 40) options) case19input
        ----------------------------------------
@@ -547,7 +590,13 @@ case19 =
 case19b :: Assertion
 case19b =
   let
-    options = Options File NewLine True InlineWithBreak RightAfter (LPConstant 17) True False False
+    options = defaultOptions
+      { importAlign    = File
+      , listAlign      = NewLine
+      , longListAlign  = InlineWithBreak
+      , emptyListAlign = RightAfter
+      , listPadding    = LPConstant 17
+      }
   in
     assertSnippet (step (Just 40) options) case19input
        ----------------------------------------
@@ -562,7 +611,13 @@ case19b =
 case19c :: Assertion
 case19c =
   let
-    options = Options File NewLine True InlineWithBreak RightAfter LPModuleName True False False
+    options = defaultOptions
+      { importAlign    = File
+      , listAlign      = NewLine
+      , longListAlign  = InlineWithBreak
+      , emptyListAlign = RightAfter
+      , listPadding    = LPModuleName
+      }
   in
     assertSnippet (step (Just 40) options) case19input
        ----------------------------------------
@@ -577,7 +632,12 @@ case19c =
 case19d :: Assertion
 case19d =
   let
-    options = Options Global NewLine True InlineWithBreak RightAfter LPModuleName True False False
+    options = defaultOptions
+      { listAlign      = NewLine
+      , longListAlign  = InlineWithBreak
+      , emptyListAlign = RightAfter
+      , listPadding    = LPModuleName
+      }
   in
     assertSnippet (step (Just 40) options) case19input
        ----------------------------------------
@@ -669,7 +729,11 @@ case22 = assertSnippet (step (Just 80) defaultOptions)
 case23 :: Assertion
 case23 =
   let
-    options = Options None AfterAlias False Inline Inherit (LPConstant 4) True True False
+    options = defaultOptions
+      { importAlign    = None
+      , padModuleNames = False
+      , spaceSurround  = True
+      }
   in
     assertSnippet (step (Just 40) options)
     [ "import Data.Acid (AcidState)"
@@ -694,7 +758,12 @@ case23 =
 case23b :: Assertion
 case23b =
   let
-    options = Options None WithModuleName False Inline Inherit (LPConstant 4) True True False
+    options = defaultOptions
+      { importAlign    = None
+      , listAlign      = WithModuleName
+      , padModuleNames = False
+      , spaceSurround  = True
+      }
   in
     assertSnippet (step (Just 40) options)
     [ "import Data.Acid (AcidState)"
@@ -720,7 +789,12 @@ case23b =
 case24 :: Assertion
 case24 =
   let
-    options = Options None AfterAlias False InlineWithBreak Inherit (LPConstant 4) True True False
+    options = defaultOptions
+      { importAlign    = None
+      , padModuleNames = False
+      , longListAlign  = InlineWithBreak
+      , spaceSurround  = True
+      }
   in
     assertSnippet (step (Just 40) options)
     [ "import Data.Acid (AcidState)"
@@ -744,7 +818,12 @@ case24 =
 case25 :: Assertion
 case25 =
   let
-    options = Options Group AfterAlias False Multiline Inherit (LPConstant 4) False False False
+    options = defaultOptions
+      { importAlign    = Group
+      , padModuleNames = False
+      , longListAlign  = Multiline
+      , separateLists  = False
+      }
   in
     assertSnippet (step (Just 80) options)
     [ "import Data.Acid (AcidState)"
@@ -930,3 +1009,285 @@ case38 = assertSnippet (step (Just 80) $ fromImportAlign File)
     [ "import Happstack.Server"
     , "import HSP"
     ]
+
+--------------------------------------------------------------------------------
+case39 :: Assertion
+case39 = assertSnippet (step Nothing options)
+  [ "import Something.A"
+  , "import SomethingElse.A"
+  , "import SomeThing.B"
+  , "import SomeThingelse.B"
+  ]
+  [ "import           SomeThing.B"
+  , ""
+  , "import           SomeThingelse.B"
+  , ""
+  , "import           Something.A"
+  , ""
+  , "import           SomethingElse.A"
+  ]
+  where options = defaultOptions { groupImports = True }
+
+--------------------------------------------------------------------------------
+case40 :: Assertion
+case40 = assertSnippet (step Nothing options)
+    [ "import Data.Default.Class (Default(def))"
+    , "import qualified Data.Aeson as JSON"
+    , "import qualified Data.Aeson as JSON"
+    , "import Control.Monad"
+    , "import Control.Monad"
+    , ""
+    , "import Data.Maybe (Maybe   (Just, Nothing))"
+    , "import qualified Data.Maybe.Extra (Maybe(Just, Nothing))"
+    , ""
+    , "import Data.Foo (Foo (Foo,Bar), Goo(Goo))"
+    , "import Data.Foo (Foo (Foo,Bar))"
+    , "import Data.Set (empty, intersect)"
+    , "import Data.Set (empty, nub)"
+    ]
+    [ "import Control.Monad"
+    , ""
+    , "import Data.Aeson         qualified as JSON"
+    , "import Data.Default.Class (Default (def))"
+    , "import Data.Foo           (Foo (Bar, Foo), Goo (Goo))"
+    , "import Data.Maybe         (Maybe (Just, Nothing))"
+    , "import Data.Maybe.Extra   qualified (Maybe (Just, Nothing))"
+    , "import Data.Set           (empty, intersect, nub)"
+    ]
+  where options = defaultOptions { groupImports = True, postQualified = True }
+
+--------------------------------------------------------------------------------
+case41 :: Assertion
+case41 = assertSnippet (step Nothing options)
+    [ "import Data.Default.Class (Default(def))"
+    , "import qualified Data.Aeson as JSON"
+    , "import Control.Monad"
+    , "import Control.Monad"
+    , "import qualified Foo.Bar.Baz"
+    , ""
+    , "import Data.Set (empty, intersect)"
+    , "import Data.Maybe (Maybe   (Just, Nothing))"
+    , "import qualified Data.Maybe.Extra (Maybe(Just, Nothing))"
+    , ""
+    , "import qualified Data.Aeson as JSON"
+    , ""
+    , "import Data.Foo (Foo (Foo,Bar), Goo(Goo))"
+    , "import Data.Foo (Foo (Foo,Bar))"
+    , "import Data.Set (empty, nub)"
+    , "import Foo.Bar.Baz (Foo)"
+    ]
+    [ "import Control.Monad"
+    , ""
+    , "import qualified Data.Aeson         as JSON"
+    , "import           Data.Default.Class (Default (def))"
+    , "import           Data.Foo           (Foo (Bar, Foo), Goo (Goo))"
+    , "import           Data.Maybe         (Maybe (Just, Nothing))"
+    , "import qualified Data.Maybe.Extra   (Maybe (Just, Nothing))"
+    , "import           Data.Set           (empty, intersect, nub)"
+    , ""
+    , "import           Foo.Bar.Baz (Foo)"
+    , "import qualified Foo.Bar.Baz"
+    ]
+  where options = defaultOptions { groupImports = True, importAlign = Group }
+
+--------------------------------------------------------------------------------
+case42 :: Assertion
+case42 =
+    assertSnippet (step (Just 80) options)
+    [ "import Data.Acid (AcidState)"
+    , "import Data.Default.Class (Default (def))"
+    , "import Control.Monad"
+    , ""
+    , "import qualified Data.Acid as Acid (closeAcidState, createCheckpoint, openLocalStateFrom)"
+    , ""
+    , "import qualified Herp.Derp.Internal.Types.Foobar as Internal (foo, bar)"
+    ]
+    [ "import Control.Monad"
+    , ""
+    , "import Data.Acid (AcidState)"
+    , "import qualified Data.Acid as Acid"
+    , "    ( closeAcidState"
+    , "    , createCheckpoint"
+    , "    , openLocalStateFrom"
+    , "    )"
+    , "import Data.Default.Class (Default (def))"
+    , ""
+    , "import qualified Herp.Derp.Internal.Types.Foobar as Internal (bar, foo)"
+    ]
+  where options = defaultOptions
+          { groupImports  = True
+          , importAlign   = None
+          , longListAlign = Multiline
+          }
+
+--------------------------------------------------------------------------------
+case43 :: Assertion
+case43 =
+    assertSnippet (step (Just 80) options)
+    [ "import Project.Internal.Blah"
+    , "import Project.Something"
+    , "import Control.Monad"
+    , ""
+    , "import qualified Data.Acid as Acid (closeAcidState, createCheckpoint, openLocalStateFrom)"
+    , ""
+    , "import qualified Project.Internal.Blarg as Blarg"
+    , "import Control.Applicative"
+    , "import Data.Functor"
+    , "import Data.Acid (AcidState)"
+    , "import Project"
+    , ""
+    , "import Data.Map (Map)"
+    , "import qualified Data.Map as Map"
+    ]
+    [ "import Project.Internal.Blah"
+    , "import qualified Project.Internal.Blarg as Blarg"
+    , ""
+    , "import Project"
+    , "import Project.Something"
+    , ""
+    , "import Control.Applicative"
+    , "import Control.Monad"
+    , ""
+    , "import Data.Acid (AcidState)"
+    , "import qualified Data.Acid as Acid"
+    , "    ( closeAcidState"
+    , "    , createCheckpoint"
+    , "    , openLocalStateFrom"
+    , "    )"
+    , "import Data.Functor"
+    , "import Data.Map (Map)"
+    , "import qualified Data.Map as Map"
+    ]
+  where options = defaultOptions
+          { groupImports  = True
+          , groupRules    =
+              [ GroupRule
+                { match = unsafeParsePattern "Project\\.Internal"
+                , subGroup = Nothing
+                }
+              , GroupRule
+                { match = unsafeParsePattern "Project"
+                , subGroup = Nothing
+                }
+              , GroupRule
+                { match = unsafeParsePattern ".*"
+                , subGroup = Just $ unsafeParsePattern "^[^.]+"
+                }
+              ]
+          , importAlign   = None
+          , longListAlign = Multiline
+          }
+
+--------------------------------------------------------------------------------
+case44a :: Assertion
+case44a =
+    assertSnippet (step (Just 80) options)
+    [ "import Project"
+    , "import Control.Monad"
+    , ""
+    , "import qualified Data.Acid as Acid"
+    , "import Project.Something"
+    , "import Data.Default.Class (Default (def))"
+    , ""
+    , "import qualified Herp.Derp.Internal.Types.Foobar as Internal (foo, bar)"
+    , "import ProJect.WrongCapitalization"
+    ]
+    [ "import Project"
+    , "import Project.Something"
+    , ""
+    , "import Control.Monad"
+    , "import qualified Data.Acid as Acid"
+    , "import Data.Default.Class (Default (def))"
+    , "import qualified Herp.Derp.Internal.Types.Foobar as Internal (bar, foo)"
+    , "import ProJect.WrongCapitalization"
+    ]
+  where options = defaultOptions
+          { groupImports = True
+          , groupRules   = [ GroupRule
+                             { match = unsafeParsePattern "Project"
+                             , subGroup = Nothing
+                             }
+                           ]
+          , importAlign  = None
+          }
+
+--------------------------------------------------------------------------------
+case44b :: Assertion
+case44b =
+    assertSnippet (step (Just 80) options)
+    [ "import Project"
+    , "import Control.Monad"
+    , ""
+    , "import qualified Data.Acid as Acid"
+    , "import Project.Something"
+    , "import Data.Default.Class (Default (def))"
+    , ""
+    , "import qualified Herp.Derp.Internal.Types.Foobar as Internal (foo, bar)"
+    , "import ProJect.WrongCapitalization"
+    ]
+    [ "import Project"
+    , "import Project.Something"
+    , ""
+    , "import qualified Data.Acid as Acid"
+    , ""
+    , "import Data.Default.Class (Default (def))"
+    , ""
+    , "import qualified Herp.Derp.Internal.Types.Foobar as Internal (bar, foo)"
+    , ""
+    , "import Control.Monad"
+    , ""
+    , "import ProJect.WrongCapitalization"
+    ]
+  where options = defaultOptions
+          { groupImports = True
+          , groupRules   =
+              [ GroupRule
+                { match = unsafeParsePattern "Project"
+                , subGroup = Nothing
+                }
+              , GroupRule
+                { match    = unsafeParsePattern "[^.]+\\.[^.]+"
+                , subGroup = Just $ unsafeParsePattern "\\.[^.]+"
+                }
+              ]
+          , importAlign  = None
+          }
+
+
+--------------------------------------------------------------------------------
+case44c :: Assertion
+case44c =
+    assertSnippet (step (Just 80) options)
+    [ "import Project"
+    , "import Control.Monad"
+    , ""
+    , "import qualified Data.Acid as Acid"
+    , "import Project.Something"
+    , "import Data.Default.Class (Default (def))"
+    , ""
+    , "import qualified Herp.Derp.Internal.Types.Foobar as Internal (foo, bar)"
+    , "import ProJect.WrongCapitalization"
+    ]
+    [ "import Project"
+    , "import Project.Something"
+    , ""
+    , "import Control.Monad"
+    , "import qualified Data.Acid as Acid"
+    , "import Data.Default.Class (Default (def))"
+    , "import qualified Herp.Derp.Internal.Types.Foobar as Internal (bar, foo)"
+    , "import ProJect.WrongCapitalization"
+    ]
+  where options = defaultOptions
+          { groupImports = True
+          , groupRules   =
+              [ GroupRule
+                { match = unsafeParsePattern "Project"
+                , subGroup = Nothing
+                }
+              , GroupRule
+                { match = unsafeParsePattern "[^.]+\\.[^.]+"
+                , subGroup = Nothing
+                }
+              ]
+          , importAlign  = None
+          }


### PR DESCRIPTION
This PR adds an option called `group_imports` (default: `false`) that automatically organizes imports into groups based on the first part of the module name:

``` haskell
import Data.List
import Control.Monad
import GHC.Exts
import Control.Applicative
import Data.Map
```

⇒

``` haskell
import Control.Applicative
import Control.Monad

import Data.List
import Data.Map

import GHC.Exts
```

I currently do this manually because I find that breaking up imports makes them much easier to scan. Now that I've started using haskell-language-server to insert most of my imports, it would be great if stylish-haskell could handle the grouping for me.

This is my first stab at the code to do this—not sure if there's a better approach.

Another option would be to let the user configure which order groups go in. Something like:

``` yaml
group_imports: ["*", "Test"]
```

which would have all groups except for `Test.*` first and `Test.*` last. The logic here would be similar to [scalafmt][1] but without regexps. This would let me configure the logic I use manually today, where I group library modules first, then test modules and finally modules internal to the current project. However, I am not sure whether this design would make sense to anybody except me and whether it's worth the added code complexity.

[1]: https://scalameta.org/scalafmt/docs/configuration.html#imports-groups