### PR TITLE
Add ghc-lib flag to force use ghc-lib-parser even if ghc is supported

### DIFF
--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -1,6 +1,6 @@
 Cabal-version: 2.4
 Name:          stylish-haskell
-Version:       0.14.2.0
+Version:       0.14.1.0
 Synopsis:      Haskell code prettifier
 Homepage:      https://github.com/haskell/stylish-haskell
 License:       BSD-3-Clause

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -23,6 +23,12 @@ Extra-source-files:
   README.markdown,
   data/stylish-haskell.yaml
 
+Flag ghc-lib
+  Default: False
+  Manual:  True
+  Description:
+    Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported
+
 Common depends
   Ghc-options:      -Wall
   Default-language: Haskell2010
@@ -46,7 +52,7 @@ Common depends
     Build-depends:
       semigroups >= 0.18 && < 0.20
 
-  if impl(ghc >= 9.2.2)
+  if impl(ghc >= 9.2.2) && (!flag(ghc-lib))
     Build-depends:
       ghc >= 9.2 && < 9.3,
       ghc-boot,

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -1,6 +1,6 @@
 Cabal-version: 2.4
 Name:          stylish-haskell
-Version:       0.14.1.0
+Version:       0.14.2.0
 Synopsis:      Haskell code prettifier
 Homepage:      https://github.com/haskell/stylish-haskell
 License:       BSD-3-Clause


### PR DESCRIPTION
Hello, this pr adds a ghc-lib flag to force use ghc-lib-parser even if ghc is supported. HLS will benefit a lot since we can support hls-stylish-haskell-plugin and hls-hlint-plugin on ghc9.2 simultaneously.  I would appreciate it if this pr is accepted with a new release. Thanks in advance.

The necessity is here https://github.com/haskell/haskell-language-server/pull/2854#discussion_r858874680