### PR TITLE
Bump resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,5 @@
-resolver: lts-19.12
+resolver: nightly-2022-06-06
 
 extra-deps:
-- 'ghc-lib-parser-9.2.2.20220307'
-- 'ghc-lib-parser-ex-9.2.0.3'
 
 save-hackage-creds: false


### PR DESCRIPTION
The resolver version is bumped to nightly-2022-06-06 which is the latest with ghc 9.2.2

This is done so that ghc-lib-parser* dependencies do not need to be defined as extra-deps
