### PR TITLE
Deriving alignment for enums

### DIFF
--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -196,8 +196,9 @@ putDataDecl cfg@Config {..} decl = do
     let derivingComments = deepAnnComments (GHC.dd_derivs defn)
 
     when (hasDeriving decl) do
-        if onelineEnum && null derivingComments then
-            space
+        if onelineEnum && null derivingComments then do
+            newline
+            spaces cDeriving
         else do
             forM_ derivingComments $ \lc -> do
                 newline

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -1377,7 +1377,7 @@ case66 :: Assertion
 case66 = assertSnippet (step indentIndentStyle) input input
   where
     input =
-      [ "data Tmp1 = A | B | C"
+      [ "data Foo = A | B | C"
       , "  deriving (Eq, Show)"
       ]
 

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -425,7 +425,8 @@ case20 = assertSnippet (step indentIndentStyle) input input
     input =
        [ "module Herp where"
        , ""
-       , "data Tag = Title | Text deriving (Eq, Show)"
+       , "data Tag = Title | Text"
+       , "  deriving (Eq, Show)"
        ]
 
 case21 :: Assertion
@@ -1162,7 +1163,8 @@ case55 :: Assertion
 case55 = assertSnippet (step sameSameNoSortStyle) input expected
   where
     input =
-       [ "data Foo = Foo deriving (Z, Y, X, Bar, Abcd)"
+       [ "data Foo = Foo"
+       , "  deriving (Z, Y, X, Bar, Abcd)"
        ]
 
     expected = input

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -78,6 +78,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 63 (issue #338)" case63
     , testCase "case 64" case64
     , testCase "case 65" case65
+    , testCase "case 66 (issue #411)" case66
     ]
 
 case00 :: Assertion
@@ -1367,6 +1368,13 @@ case65 = assertSnippet (step indentIndentStyle) input input
         , "  deriving (Show)"
         ]
 
+case66 :: Assertion
+case66 = assertSnippet (step indentIndentStyle) input input
+  where
+    input =
+      [ "data Tmp1 = A | B | C"
+      , "  deriving (Eq, Show)"
+      ]
 sameSameStyle :: Config
 sameSameStyle = Config SameLine SameLine 2 2 False True SameLine False True NoMaxColumns
 

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -1368,6 +1368,9 @@ case65 = assertSnippet (step indentIndentStyle) input input
         , "  deriving (Show)"
         ]
 
+-- | Deriving alignment for enums
+--
+-- Regression test for https://github.com/haskell/stylish-haskell/issues/411
 case66 :: Assertion
 case66 = assertSnippet (step indentIndentStyle) input input
   where
@@ -1375,6 +1378,7 @@ case66 = assertSnippet (step indentIndentStyle) input input
       [ "data Tmp1 = A | B | C"
       , "  deriving (Eq, Show)"
       ]
+
 sameSameStyle :: Config
 sameSameStyle = Config SameLine SameLine 2 2 False True SameLine False True NoMaxColumns
 


### PR DESCRIPTION
Fixes #411

I've changed printer's behavior for alignment of deriving closes: now it adds newline and indentation before `deriving` even if `onelineEnum` is enabled:
```hs
data Foo = A | B | C
  deriving (Eq, Show)
```
instead of
```hs
data Foo = A | B | C deriving (Eq, Show)
```
This behavior is what is said in docs:

> Deriving clauses are always on separate lines

Surely we can add an option to preserve the previous behavior, but I don't think that it's desired for several reasons:

- it conflicts with docs
- it leads to an awful output when enum is large, that even not highlight well:
```hs
data DefType = DefTEnv | DefTPref | DefTCmd | DefTInl | DefTMode | DefTSort deriving
    ( Eq
    , Ord
    , Show
    )
```

However, if you think otherwise, I can add an option. Maybe while `break_enums` option was discussed the reasons of this choice were expained, but I couldn't find anything.

Only two tests were affected by this change:

- case 20 (establish the `break_enums` option) 

Before:
```hs
data Tag = Title | Text deriving (Eq, Show)
```
After:
```hs
data Tag = Title | Text 
  deriving (Eq, Show)
```

- case 55 (issue #262, not related to `deriving` problem)

Before:
```hs
data Foo = Foo deriving (Z, Y, X, Bar, Abcd)
```
After:
```hs
data Foo = Foo 
  deriving (Z, Y, X, Bar, Abcd)
```