### PR TITLE
changes for most recent Cabal

### DIFF
--- a/lib/Language/Haskell/Stylish/Config/Cabal.hs
+++ b/lib/Language/Haskell/Stylish/Config/Cabal.hs
@@ -9,7 +9,7 @@ import           Data.Either                              (isRight)
 import           Data.List                                (nub)
 import           Data.Maybe                               (maybeToList)
 import qualified Distribution.PackageDescription          as Cabal
-import qualified Distribution.PackageDescription.Parsec   as Cabal
+import qualified Distribution.Simple.PackageDescription   as Cabal
 import qualified Distribution.Simple.Utils                as Cabal
 import qualified Distribution.Verbosity                   as Cabal
 import qualified Language.Haskell.Extension               as Language
@@ -40,7 +40,7 @@ findCabalFile verbose = do
     _ -> do
       verbose $ ".cabal file not found, directories searched: " <>
         show potentialProjectRoots
-      verbose $ "Stylish Haskell will work basing on LANGUAGE pragmas in source files."
+      verbose "Stylish Haskell will work basing on LANGUAGE pragmas in source files."
       return Nothing
 
 

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -37,7 +37,7 @@ Common depends
     aeson             >= 0.6    && < 2.1,
     base              >= 4.8    && < 5,
     bytestring        >= 0.9    && < 0.12,
-    Cabal             >= 3.4    && < 4.0,
+    Cabal             >= 3.8    && < 4.0,
     containers        >= 0.3    && < 0.7,
     directory         >= 1.2.3  && < 1.4,
     filepath          >= 1.1    && < 1.5,


### PR DESCRIPTION
Maybe it's not `Cabal             >= 3.8` and should be `Cabal             >= 3.9`

also don't know if there must be some conditional import depending on cabal version