### PR TITLE
Inline comment to a record constructor lead to non idempotent behavior

### DIFF
--- a/lib/Language/Haskell/Stylish/Comments.hs
+++ b/lib/Language/Haskell/Stylish/Comments.hs
@@ -102,9 +102,9 @@ takeNext [] ((cb, c) : comments) =
 takeNext ((ib, i) : items) [] =
     Just (ib, NextItem i, items, [])
 takeNext ((ib, i) : items) ((cb, c) : comments)
-    | blockStart ib == blockStart cb =
+    | blockEnd ib == blockStart cb =
         Just (ib <> cb, NextItemWithComment i c, items, comments)
-    | blockStart ib < blockStart cb =
+    | blockEnd ib < blockStart cb =
         Just (ib, NextItem i, items, (cb, c) : comments)
     | otherwise =
         Just (cb, NextComment c, (ib, i) : items, comments)

--- a/lib/Language/Haskell/Stylish/Comments.hs
+++ b/lib/Language/Haskell/Stylish/Comments.hs
@@ -102,12 +102,10 @@ takeNext [] ((cb, c) : comments) =
 takeNext ((ib, i) : items) [] =
     Just (ib, NextItem i, items, [])
 takeNext ((ib, i) : items) ((cb, c) : comments)
-    | blockEnd ib == blockStart cb =
-        Just (ib <> cb, NextItemWithComment i c, items, comments)
-    | blockEnd ib < blockStart cb =
-        Just (ib, NextItem i, items, (cb, c) : comments)
-    | otherwise =
-        Just (cb, NextComment c, (ib, i) : items, comments)
+    = case blockEnd ib `compare` blockStart cb of
+        EQ -> Just (ib <> cb, NextItemWithComment i c, items, comments)
+        LT -> Just (ib, NextItem i, items, (cb, c) : comments)
+        GT -> Just (cb, NextComment c, (ib, i) : items, comments)
 
 
 --------------------------------------------------------------------------------

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -97,9 +97,10 @@ step cfg = makeStep "Data" \ls m -> Editor.apply (changes m) ls
         ldecl <- GHC.hsmodDecls $ GHC.unLoc m
         GHC.TyClD _ tycld <- pure $ GHC.unLoc ldecl
         loc <- maybeToList $ GHC.srcSpanToRealSrcSpan $ GHC.getLocA ldecl
+        let lastInlineComment = GHC.ann $ GHC.getLoc ldecl
         case tycld of
             GHC.DataDecl {..} -> pure $ MkDataDecl
-                { dataComments = epAnnComments tcdDExt
+                { dataComments = epAnnComments lastInlineComment <> epAnnComments tcdDExt
                 , dataLoc      = loc
                 , dataDeclName = tcdLName
                 , dataTypeVars = tcdTyVars

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -79,6 +79,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 64" case64
     , testCase "case 65" case65
     , testCase "case 66 (issue #411)" case66
+    , testCase "case 67 (issue #425)" case67
     ]
 
 case00 :: Assertion
@@ -1379,6 +1380,24 @@ case66 = assertSnippet (step indentIndentStyle) input input
     input =
       [ "data Foo = A | B | C"
       , "  deriving (Eq, Show)"
+      ]
+
+-- | Inline comment after the last record field
+--
+-- Regression test for https://github.com/haskell/stylish-haskell/issues/425
+case67 :: Assertion
+case67 = assertSnippet (step indentIndentStyle) input input
+  where
+    input =
+      [ "data Foo"
+      , "  = Foo -- ^ foo"
+      , "  | Bar -- ^ bar"
+      , "  | Baz -- ^ baz"
+      , ""
+      , "data Foo'"
+      , "  = Foo' Int -- ^ foo"
+      , "  | Bar' Int -- ^ bar"
+      , "  | Baz' Int -- ^ baz"
       ]
 
 sameSameStyle :: Config

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -80,6 +80,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 65" case65
     , testCase "case 66 (issue #411)" case66
     , testCase "case 67 (issue #425)" case67
+    , testCase "case 68 (issue #426)" case68
     ]
 
 case00 :: Assertion
@@ -1398,6 +1399,23 @@ case67 = assertSnippet (step indentIndentStyle) input input
       , "  = Foo' Int -- ^ foo"
       , "  | Bar' Int -- ^ bar"
       , "  | Baz' Int -- ^ baz"
+      ]
+
+-- | Inline comment at the different line, than the start of the block
+-- (record constructor)
+--
+-- Regression test for https://github.com/haskell/stylish-haskell/issues/426
+case68 :: Assertion
+case68 = assertSnippet (step indentIndentStyle) input input
+  where
+    input =
+      [ "data Foo"
+      , "  = Foo"
+      , "      { foo :: Int"
+      , "      } -- ^ foo"
+      , "  | Bar"
+      , "      { bar :: Int"
+      , "      } -- ^ bar"
       ]
 
 sameSameStyle :: Config


### PR DESCRIPTION
closes #426

This branch is based on the #427 because, as I think, we should test the correct behavior for comments to the last constructor here too, but without that fix its impossible. So this pull request should be considered after that will be merged.

It seems that #354 may be related to this or even parially fixed by this pull request, but as far as I see, current stylish-haskell's behavior with `LANGUAGE CPP` and `LINE` pragmas is very strange itself, therefore I can't esablish what the right behavior should be in that case (and without enabling both of them I can't find any bug there