### PR TITLE
Specify the utf-8 encoding for the output handle

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -163,6 +163,7 @@ file sa conf mfp = do
                 Just _    | not (saInPlace sa) -> putStrNewline new
                 Just path | not (null new) && old /= new  ->
                     IO.withFile path IO.WriteMode $ \h -> do
+                        IO.hSetEncoding h IO.utf8
                         setNewlineMode h
                         IO.hPutStr h new
                 _ -> return ()


### PR DESCRIPTION
The problem is related to #108, however wasn't fixed. I'm working on windows and have a problem with the latest version from haskell/stylish-haskell (#428). Maybe printing to the file in utf-8 by default is not what we want by default if system default encoding is not utf-8? However, at least in the case when UnicodeSyntax is enabled it definitely should be so.