### PR TITLE
More unicode syntax replacements

### DIFF
--- a/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
+++ b/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
@@ -44,6 +44,7 @@ hsAddEpAnnReplacements :: GHC.AddEpAnn -> Editor.Edits
 hsAddEpAnnReplacements (GHC.AddEpAnn el (GHC.EpaSpan loc)) = case el of
     GHC.AnnDcolon -> Editor.replaceRealSrcSpan loc "∷"
     GHC.AnnForall -> Editor.replaceRealSrcSpan loc "∀"
+    GHC.AnnLarrow -> Editor.replaceRealSrcSpan loc "←"
     _ -> mempty
 hsAddEpAnnReplacements _ = mempty
 

--- a/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
+++ b/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
@@ -1,4 +1,7 @@
 --------------------------------------------------------------------------------
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 module Language.Haskell.Stylish.Step.UnicodeSyntax
     ( step
     ) where
@@ -16,25 +19,32 @@ import           Language.Haskell.Stylish.Step
 import           Language.Haskell.Stylish.Step.LanguagePragmas (addLanguagePragma)
 import           Language.Haskell.Stylish.Util                 (everything)
 
+--------------------------------------------------------------------------------
+hsArrowReplacements :: GHC.HsArrow GHC.GhcPs -> Editor.Edits
+hsArrowReplacements = \case
+    GHC.HsUnrestrictedArrow (GHC.L (GHC.TokenLoc l) GHC.HsNormalTok) ->
+        Editor.replaceRealSrcSpan (GHC.epaLocationRealSrcSpan l) "→"
+    GHC.HsLinearArrow (GHC.HsPct1 _ (GHC.L (GHC.TokenLoc l) GHC.HsNormalTok)) ->
+        Editor.replaceRealSrcSpan (GHC.epaLocationRealSrcSpan l) "→"
+    GHC.HsExplicitMult _ _ (GHC.L (GHC.TokenLoc l) GHC.HsNormalTok) ->
+        Editor.replaceRealSrcSpan (GHC.epaLocationRealSrcSpan l) "→"
+    _ -> mempty
+
 
 --------------------------------------------------------------------------------
-hsTyReplacements :: GHC.HsType GHC.GhcPs -> Editor.Edits
-hsTyReplacements (GHC.HsFunTy _ arr _ _)
-    | GHC.HsUnrestrictedArrow (GHC.L (GHC.TokenLoc epaLoc) GHC.HsNormalTok) <- arr=
-        Editor.replaceRealSrcSpan (GHC.epaLocationRealSrcSpan epaLoc) "→"
-hsTyReplacements (GHC.HsQualTy _ ctx _)
-    | Just arrow <- GHC.ac_darrow . GHC.anns . GHC.ann $ GHC.getLoc ctx
-    , (GHC.NormalSyntax, GHC.EpaSpan loc) <- arrow =
+hsAnnContextReplacements :: GHC.AnnContext -> Editor.Edits
+hsAnnContextReplacements (GHC.AnnContext{GHC.ac_darrow})
+    | Just (GHC.NormalSyntax, GHC.EpaSpan loc) <- ac_darrow =
         Editor.replaceRealSrcSpan loc "⇒"
-hsTyReplacements _ = mempty
+    | otherwise = mempty
+
 
 --------------------------------------------------------------------------------
-hsSigReplacements :: GHC.Sig GHC.GhcPs -> Editor.Edits
-hsSigReplacements (GHC.TypeSig ann _ _)
-    | GHC.AddEpAnn GHC.AnnDcolon epaLoc <- GHC.asDcolon $ GHC.anns ann
-    , GHC.EpaSpan loc <- epaLoc =
+hsAddEpAnnReplacements :: GHC.AddEpAnn -> Editor.Edits
+hsAddEpAnnReplacements (GHC.AddEpAnn GHC.AnnDcolon epaLoc)
+    | GHC.EpaSpan loc <- epaLoc =
         Editor.replaceRealSrcSpan loc "∷"
-hsSigReplacements _ = mempty
+hsAddEpAnnReplacements _ = mempty
 
 
 --------------------------------------------------------------------------------
@@ -46,7 +56,7 @@ step = (makeStep "UnicodeSyntax" .) . step'
 step' :: Bool -> String -> Lines -> Module -> Lines
 step' alp lg ls modu = Editor.apply edits ls
   where
-    edits =
-        foldMap hsTyReplacements (everything modu) <>
-        foldMap hsSigReplacements (everything modu) <>
+    edits = foldMap hsArrowReplacements  (everything  modu) <>
+        foldMap hsAnnContextReplacements (everything modu) <>
+        foldMap hsAddEpAnnReplacements (everything modu) <>
         (if alp then addLanguagePragma lg "UnicodeSyntax" modu else mempty)

--- a/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
+++ b/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
@@ -45,6 +45,19 @@ hsAddEpAnnReplacements (GHC.AddEpAnn el (GHC.EpaSpan loc)) = case el of
     GHC.AnnDcolon -> Editor.replaceRealSrcSpan loc "∷"
     GHC.AnnForall -> Editor.replaceRealSrcSpan loc "∀"
     GHC.AnnLarrow -> Editor.replaceRealSrcSpan loc "←"
+    GHC.Annlarrowtail -> Editor.replaceRealSrcSpan loc "⤙"
+    GHC.Annrarrowtail -> Editor.replaceRealSrcSpan loc "→"
+    GHC.AnnLarrowtail -> Editor.replaceRealSrcSpan loc "⤛"
+    GHC.AnnRarrowtail -> Editor.replaceRealSrcSpan loc "⤜"
+    GHC.AnnOpenB  -> Editor.replaceRealSrcSpan loc "⦇"
+    GHC.AnnCloseB -> Editor.replaceRealSrcSpan loc "⦈"
+    GHC.AnnOpenEQ -> Editor.replaceRealSrcSpan loc "⟦"
+    GHC.AnnCloseQ -> Editor.replaceRealSrcSpan loc "⟧"
+    -- doesn't work here, as far as I can see, so implemented
+    -- in separate functions:
+    GHC.AnnDarrow -> Editor.replaceRealSrcSpan loc "⇒"
+    GHC.AnnRarrow -> Editor.replaceRealSrcSpan loc "→"
+
     _ -> mempty
 hsAddEpAnnReplacements _ = mempty
 

--- a/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
+++ b/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
@@ -41,9 +41,10 @@ hsAnnContextReplacements (GHC.AnnContext{GHC.ac_darrow})
 
 --------------------------------------------------------------------------------
 hsAddEpAnnReplacements :: GHC.AddEpAnn -> Editor.Edits
-hsAddEpAnnReplacements (GHC.AddEpAnn GHC.AnnDcolon epaLoc)
-    | GHC.EpaSpan loc <- epaLoc =
-        Editor.replaceRealSrcSpan loc "∷"
+hsAddEpAnnReplacements (GHC.AddEpAnn el (GHC.EpaSpan loc)) = case el of
+    GHC.AnnDcolon -> Editor.replaceRealSrcSpan loc "∷"
+    GHC.AnnForall -> Editor.replaceRealSrcSpan loc "∀"
+    _ -> mempty
 hsAddEpAnnReplacements _ = mempty
 
 

--- a/tests/Language/Haskell/Stylish/Step/UnicodeSyntax/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/UnicodeSyntax/Tests.hs
@@ -25,6 +25,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.UnicodeSyntax.Tests"
     , testCase "case 04 (GADTs)" case04
     , testCase "case 05 (Linear types)" case05
     , testCase "case 06 (Forall)" case06
+    , testCase "case 07 (do notation)" case07
     ]
 
 
@@ -119,4 +120,17 @@ case06 = assertSnippet (step False "LANGUAGE")
     , ""
     , "data Foo where"
     , "  Foo ∷ ∀ a. Show a ⇒ a → Foo"
+    ]
+
+case07 :: Assertion
+case07 = assertSnippet (step False "LANGUAGE")
+    [ "main :: IO ()"
+    , "  main = do"
+    , "  s <- getLine"
+    , "  putStrLn s"
+    ]
+    [ "main ∷ IO ()"
+    , "  main = do"
+    , "  s ← getLine"
+    , "  putStrLn s"
     ]

--- a/tests/Language/Haskell/Stylish/Step/UnicodeSyntax/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/UnicodeSyntax/Tests.hs
@@ -22,6 +22,8 @@ tests = testGroup "Language.Haskell.Stylish.Step.UnicodeSyntax.Tests"
     [ testCase "case 01" case01
     , testCase "case 02" case02
     , testCase "case 03" case03
+    , testCase "case 04 (GADTs)" case04
+    , testCase "case 05 (Linear types)" case05
     ]
 
 
@@ -57,4 +59,38 @@ case03 = assertSnippet (step False "LANGUAGE")
     ]
     [ "x ∷ Int → Int → Int"
     , "x = undefined"
+    ]
+
+case04 :: Assertion
+case04 = assertSnippet (step False "LANGUAGE")
+    [ "data Foo where"
+    , "  Foo0 :: Foo"
+    , "  Foo1 :: Int -> Foo"
+    , "  Foo2 :: Int -> Bool -> Foo"
+    , "  FooC :: Show a => a -> Foo"
+    ]
+    [ "data Foo where"
+    , "  Foo0 ∷ Foo"
+    , "  Foo1 ∷ Int → Foo"
+    , "  Foo2 ∷ Int → Bool → Foo"
+    , "  FooC ∷ Show a ⇒ a → Foo"
+    ]
+
+case05 :: Assertion
+case05 = assertSnippet (step False "LANGUAGE")
+    [ "{-# LANGUAGE LinearTypes #-}"
+    , ""
+    , "construct :: Int -> a %1 -> T1 a"
+    , "construct _ x = MkT1 x"
+    , ""
+    , "data T3 a m where"
+    , "  MkT3 :: a %m -> T3 a m"
+    ]
+    [ "{-# LANGUAGE LinearTypes #-}"
+    , ""
+    , "construct ∷ Int → a %1 → T1 a"
+    , "construct _ x = MkT1 x"
+    , ""
+    , "data T3 a m where"
+    , "  MkT3 ∷ a %m → T3 a m"
     ]

--- a/tests/Language/Haskell/Stylish/Step/UnicodeSyntax/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/UnicodeSyntax/Tests.hs
@@ -24,6 +24,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.UnicodeSyntax.Tests"
     , testCase "case 03" case03
     , testCase "case 04 (GADTs)" case04
     , testCase "case 05 (Linear types)" case05
+    , testCase "case 06 (Forall)" case06
     ]
 
 
@@ -93,4 +94,29 @@ case05 = assertSnippet (step False "LANGUAGE")
     , ""
     , "data T3 a m where"
     , "  MkT3 ∷ a %m → T3 a m"
+    ]
+
+case06 :: Assertion
+case06 = assertSnippet (step False "LANGUAGE")
+    [ "{-# LANGUAGE ScopedTypeVariables #-}"
+    , ""
+    , "err :: forall a. a"
+    , "err = undefined"
+    , ""
+    , "foo :: forall a. Int -> (forall b. Show b => b -> a) -> Bool"
+    , "foo = undefined"
+    , ""
+    , "data Foo where"
+    , "  Foo :: forall a. Show a => a -> Foo"
+    ]
+    [ "{-# LANGUAGE ScopedTypeVariables #-}"
+    , ""
+    , "err ∷ ∀ a. a"
+    , "err = undefined"
+    , ""
+    , "foo ∷ ∀ a. Int → (∀ b. Show b ⇒ b → a) → Bool"
+    , "foo = undefined"
+    , ""
+    , "data Foo where"
+    , "  Foo ∷ ∀ a. Show a ⇒ a → Foo"
     ]

--- a/tests/Language/Haskell/Stylish/Step/UnicodeSyntax/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/UnicodeSyntax/Tests.hs
@@ -26,6 +26,8 @@ tests = testGroup "Language.Haskell.Stylish.Step.UnicodeSyntax.Tests"
     , testCase "case 05 (Linear types)" case05
     , testCase "case 06 (Forall)" case06
     , testCase "case 07 (do notation)" case07
+    , testCase "case 08 (arrow syntax)" case08
+    , testCase "case 09 (TH quotes)" case09
     ]
 
 
@@ -133,4 +135,34 @@ case07 = assertSnippet (step False "LANGUAGE")
     , "  main = do"
     , "  s ← getLine"
     , "  putStrLn s"
+    ]
+
+case08 :: Assertion
+case08 = assertSnippet (step False "LANGUAGE")
+    [ "{-# LANGUAGE Arrows #-}"
+    , ""
+    , "a = proc x -> do"
+    , "  y <- f -< x+1"
+    , "  (|untilA (increment -< x+y) (within 0.5 -< x)|)"
+    , ""
+    , "b = proc x -> f x -<< x+1"
+    ]
+    [ "{-# LANGUAGE Arrows #-}"
+    , ""
+    , "a = proc x → do"
+    , "  y ← f ⤙ x+1"
+    , "  ⦇untilA (increment ⤙ x+y) (within 0.5 ⤙ x)⦈"
+    , ""
+    , "b = proc x → f x ⤛ x+1"
+    ]
+
+case09 :: Assertion
+case09 = assertSnippet (step False "LANGUAGE")
+    [ "{-# LANGUAGE QuasiQuotes #-}"
+    , ""
+    , "exp = [| 2 + 2 |]"
+    ]
+    [ "{-# LANGUAGE QuasiQuotes #-}"
+    , ""
+    , "exp = ⟦ 2 + 2 ⟧"
     ]


### PR DESCRIPTION
I've refactored UnicodeSyntax step and extended number of replacable symbols. Old replacement rules for `->`, `::` and `=>` in function type declaration were replaced by more abstract, working for GADTs too. Many other symbols added.

There are some problems with Arrow notation: in [official documentation](https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/arrows.html) I've found only two operators: `-<` and `-<<`. According two the GHC [parser lib](https://hackage.haskell.org/package/ghc-9.4.2/docs/GHC-Parser-Annotation.html#t:AnnKeywordId) there is also `>>-`.  I've added appropriate replacement rule without tests. 

I've added several base test cases, maybe missed some significant point. I'd be glad for any remarks and corrections 