### PR TITLE
Disabling formatting of the block of code

### DIFF
--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -87,7 +87,7 @@ defaultConfig = Config
     }
 
 step :: Config -> Step
-step cfg = makeStep "Data" \ls m -> Editor.apply (changes m) ls
+step cfg = makeStep "Data" \ls m -> Editor.apply (changes m) m ls
   where
     changes :: Module -> Editor.Edits
     changes = foldMap (formatDataDecl cfg) . dataDecls

--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -204,7 +204,7 @@ step columns = makeStep "Imports (ghc-lib-parser)" . printImports columns
 
 --------------------------------------------------------------------------------
 printImports :: Maybe Int -> Options -> Lines -> Module -> Lines
-printImports maxCols options ls m = Editor.apply changes ls
+printImports maxCols options ls m = Editor.apply changes m ls
   where
     groups = moduleImportGroups m
     moduleStats = foldMap importStats . fmap GHC.unLoc $ concatMap toList groups

--- a/lib/Language/Haskell/Stylish/Step/LanguagePragmas.hs
+++ b/lib/Language/Haskell/Stylish/Step/LanguagePragmas.hs
@@ -121,7 +121,7 @@ step = ((((makeStep "LanguagePragmas" .) .) .) .) . step'
 step' :: Maybe Int -> Style -> Bool -> Bool -> String -> Lines -> Module -> Lines
 step' columns style align removeRedundant lngPrefix ls m
   | null languagePragmas = ls
-  | otherwise = Editor.apply changes ls
+  | otherwise = Editor.apply changes m ls
   where
     isRedundant'
         | removeRedundant = isRedundant m

--- a/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
+++ b/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
@@ -113,7 +113,7 @@ printModuleHeader maxCols conf ls lmodul =
             (Editor.Block startLine endLine)
             (const printedModuleHeader) in
 
-    Editor.apply changes ls
+    Editor.apply changes lmodul ls
   where
     doSort = if sort conf then fmap (commentGroupSort compareLIE) else id
 

--- a/lib/Language/Haskell/Stylish/Step/SimpleAlign.hs
+++ b/lib/Language/Haskell/Stylish/Step/SimpleAlign.hs
@@ -196,4 +196,4 @@ step maxColumns config = makeStep "Cases" $ \ls module' ->
             changes records (recordToAlignable config) <>
             changes everything (matchGroupToAlignable config) <>
             changes everything (multiWayIfToAlignable config) in
-    Editor.apply configured ls
+    Editor.apply configured module' ls

--- a/lib/Language/Haskell/Stylish/Step/Squash.hs
+++ b/lib/Language/Haskell/Stylish/Step/Squash.hs
@@ -82,8 +82,8 @@ matchSeparator _ = Nothing
 
 --------------------------------------------------------------------------------
 step :: Step
-step = makeStep "Squash" $ \ls (module') ->
+step = makeStep "Squash" $ \ls module' ->
     let changes =
             foldMap squashFieldDecl (everything module') <>
             foldMap squashMatch (everything module') in
-    Editor.apply changes ls
+    Editor.apply changes module' ls

--- a/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
+++ b/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
@@ -44,7 +44,7 @@ step = (makeStep "UnicodeSyntax" .) . step'
 
 --------------------------------------------------------------------------------
 step' :: Bool -> String -> Lines -> Module -> Lines
-step' alp lg ls modu = Editor.apply edits ls
+step' alp lg ls modu = Editor.apply edits modu ls
   where
     edits =
         foldMap hsTyReplacements (everything modu) <>

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -122,6 +122,7 @@ Test-suite stylish-haskell-tests
     Language.Haskell.Stylish.Config.Tests
     Language.Haskell.Stylish.Parse.Tests
     Language.Haskell.Stylish.Regressions
+    Language.Haskell.Stylish.Disabling
     Language.Haskell.Stylish.Step.Data.Tests
     Language.Haskell.Stylish.Step.Imports.FelixTests
     Language.Haskell.Stylish.Step.Imports.Tests

--- a/tests/Language/Haskell/Stylish/Disabling.hs
+++ b/tests/Language/Haskell/Stylish/Disabling.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedLists #-}
+module Language.Haskell.Stylish.Disabling where
+
+import qualified Language.Haskell.Stylish.Step.ModuleHeader  as Header
+import qualified Language.Haskell.Stylish.Step.Data          as Data
+import qualified Language.Haskell.Stylish.Step.UnicodeSyntax as Unicode
+import           Language.Haskell.Stylish.Tests.Util (assertSnippet)
+import           Test.Framework                      (Test, testGroup)
+import           Test.Framework.Providers.HUnit      (testCase)
+import           Test.HUnit                          (Assertion)
+
+
+tests :: Test
+tests = testGroup "Language.Haskell.Stylish.Disabling"
+    [ testCase "Header formatiing disabled" case00
+    , testCase "One of several Datas formatting disabled" case01
+    , testCase "Unicode (one-symbol replacement)" case02
+    ]
+
+--------------------------------------------------------------------------------
+case00 :: Assertion
+case00 = assertSnippet (Header.step (Just 80) Header.defaultConfig) inp inp
+  where
+    inp =
+      [ "{- STYLISH_DISABLE -}"
+      , "module Main (foo, bar) where"
+      , "{- STYLISH_ENABLE -}"
+      ]
+
+--------------------------------------------------------------------------------
+case01 :: Assertion
+case01 = assertSnippet (Data.step Data.defaultConfig)
+  [ "data Foo = Foo"
+  , ""
+  , "{-     stylish_disable   -}"
+  , "data Bar = Bar"
+  , "{-     stylish_enable    -}"
+  , "data Baz = Baz"
+  ]
+  [ "data Foo"
+  , "    = Foo"
+  , ""
+  , "{-     stylish_disable   -}"
+  , "data Bar = Bar"
+  , "{-     stylish_enable    -}"
+  , "data Baz"
+  , "    = Baz"
+  ]
+
+
+--------------------------------------------------------------------------------
+case02 :: Assertion
+case02 = assertSnippet (Unicode.step True "LANGUAGE")
+  [ "foo :: Int -> String"
+  , "foo = undefined"
+  , "{- stylish_disable -}"
+  , "bar :: Int"
+  , "bar = undefined"
+  , "{- stylish_enable -}"
+  , ""
+  , "baz :: String {- stylish_disable -}"
+  , "baz = undefined"
+  , "{- stylish_enable -} baz' :: Int"
+  , "baz' = undefined"
+  ]
+  [ "{-# LANGUAGE UnicodeSyntax #-}"
+  , "foo ∷ Int → String"
+  , "foo = undefined"
+  , "{- stylish_disable -}"
+  , "bar :: Int"
+  , "bar = undefined"
+  , "{- stylish_enable -}"
+  , ""
+  , "baz :: String {- stylish_disable -}"
+  , "baz = undefined"
+  , "{- stylish_enable -} baz' :: Int"
+  , "baz' = undefined"
+  ]

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -23,6 +23,7 @@ import qualified Language.Haskell.Stylish.Step.TrailingWhitespace.Tests
 import qualified Language.Haskell.Stylish.Step.UnicodeSyntax.Tests
 import qualified Language.Haskell.Stylish.Tests
 import qualified Language.Haskell.Stylish.Regressions
+import qualified Language.Haskell.Stylish.Disabling
 
 
 --------------------------------------------------------------------------------
@@ -42,4 +43,5 @@ main = defaultMain
     , Language.Haskell.Stylish.Step.UnicodeSyntax.Tests.tests
     , Language.Haskell.Stylish.Tests.tests
     , Language.Haskell.Stylish.Regressions.tests
+    , Language.Haskell.Stylish.Disabling.tests
     ]


### PR DESCRIPTION
Here is one of the possible solutions to this issue. It's very straightforward: just collecting all edits and then filtering them and applying only those, that doesn't intersect with the block of code between `{- stylish_disable -}` and `{- stylish_enable -}`.

Filtering is applied by rows only, so, in this sample
```hs
data Foo = Foo Int {- stylish_disable -}
{- stylish_enable -}
```
data will not be reformated. In the first my iplementation columns also were taken into account, but this made the code much more havier and didn't make much sense for me: such constructions as in example above seems too artificial.

Anyway this issue was discussed many times here (#409 is the latest one). So it seems to be very helpful feature, not for me only. So it would be nice to discuss and resolve it one way or another 