### PR TITLE
Fixed NoXyz issue for .cabal files

### DIFF
--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -123,14 +123,15 @@ loadConfig verbose userSpecified = do
         Left (pos, err)     -> error $ prettyPosWithSource pos (fromStrict bytes) ("Language.Haskell.Stylish.Config.loadConfig: " ++ err)
         Right config -> do
           cabalLanguageExtensions <- if configCabal config
-            then map show <$> Cabal.findLanguageExtensions verbose
+            then map toStr <$> Cabal.findLanguageExtensions verbose
             else pure []
 
           return $ config
             { configLanguageExtensions = nub $
                 configLanguageExtensions config ++ cabalLanguageExtensions
             }
-
+    where toStr (ext, True)  = show ext
+          toStr (ext, False) = "No" ++ show ext
 
 --------------------------------------------------------------------------------
 parseConfig :: A.Value -> A.Parser Config

--- a/tests/Language/Haskell/Stylish/Config/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Config/Tests.hs
@@ -29,6 +29,10 @@ tests = testGroup "Language.Haskell.Stylish.Config"
                testExtensionsFromDotStylish
     , testCase "Extensions extracted correctly from .stylish-haskell.yaml and .cabal files"
                testExtensionsFromBoth
+    , testCase "NoXyz extensions from .stylish-haskell.yaml file"
+               testStylishNoXyz
+    , testCase "NoXyz extensions from .cabal file"
+               testCabalNoXyz
     , testCase "Correctly read .stylish-haskell.yaml file with default max column number"
                testDefaultColumns
     , testCase "Correctly read .stylish-haskell.yaml file with specified max column number"
@@ -111,6 +115,16 @@ testExtensionsFromBoth = testExtensions
     [ cabalCfg dotCabal ["ScopedTypeVariables"] ["DataKinds"]
     , stylishCfg dotStylish ["TemplateHaskell", "QuasiQuotes"]
     ]
+
+--------------------------------------------------------------------------------
+testStylishNoXyz :: Assertion
+testStylishNoXyz = testExtensions
+    [ stylishCfg dotStylish ["NoStarIsType", "NoTypeOperators"] ]
+
+--------------------------------------------------------------------------------
+testCabalNoXyz :: Assertion
+testCabalNoXyz = testExtensions
+    [ cabalCfg dotCabal ["NoStarIsType"] ["NoTypeOperators"] ]
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This is just like #412, but for .cabal files. This is what actually caused #414, so I hope it will be closed by the PR.

Also I've improved a bit tests for config parsing. I think they are not optimal, but now they are a bit better, than they were.

For the future plans I think it would be nice to some algebraic type for dealing with extensions. The current solution "via show" seems ugly and error-prone.  