### PR TITLE
Disapearing of `DEPRECATED` pragma attached to module fixed

### DIFF
--- a/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
+++ b/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
@@ -31,6 +31,7 @@ import           Language.Haskell.Stylish.Printer
 import           Language.Haskell.Stylish.Step
 import qualified Language.Haskell.Stylish.Step.Imports as Imports
 import           Language.Haskell.Stylish.Util         (flagEnds)
+import qualified GHC.Unit.Module.Warnings as GHC
 
 
 data Config = Config
@@ -70,6 +71,8 @@ printModuleHeader maxCols conf ls lmodul =
     let modul = GHC.unLoc lmodul
         name = GHC.unLoc <$> GHC.hsmodName modul
 
+        deprecMsg = GHC.hsmodDeprecMessage modul
+
         startLine = fromMaybe 1 $ moduleLine <|>
             (fmap GHC.srcSpanStartLine . GHC.srcSpanToRealSrcSpan $
                 GHC.getLoc lmodul)
@@ -107,7 +110,7 @@ printModuleHeader maxCols conf ls lmodul =
         printedModuleHeader = runPrinter_
             (PrinterConfig maxCols)
             (printHeader
-                conf name exportGroups moduleComment whereComment)
+                conf name deprecMsg exportGroups moduleComment whereComment)
 
         changes = Editor.changeLines
             (Editor.Block startLine endLine)
@@ -120,15 +123,20 @@ printModuleHeader maxCols conf ls lmodul =
 printHeader
     :: Config
     -> Maybe GHC.ModuleName
+    -> Maybe (GHC.LocatedP (GHC.WarningTxt GHC.GhcPs))
     -> Maybe [CommentGroup (GHC.LIE GHC.GhcPs)]
     -> Maybe GHC.LEpaComment  -- Comment attached to 'module'
     -> Maybe GHC.LEpaComment  -- Comment attached to 'where'
     -> P ()
-printHeader conf mbName mbExps mbModuleComment mbWhereComment = do
+printHeader conf mbName mbDeprec mbExps mbModuleComment mbWhereComment = do
     forM_ mbName $ \name -> do
         putText "module"
         space
         putText (showOutputable name)
+
+    forM_ mbDeprec \deprec -> do
+        putText " "
+        putText (showOutputable deprec)
 
     case mbExps of
         Nothing -> do

--- a/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
@@ -82,6 +82,7 @@ tests = testGroup "Language.Haskell.Stylish.Printer.ModuleHeader"
     , testCase "Single one module comment" ex32
     , testCase "Inline comments" ex33
     , testCase "Deprecated pragma to the module" ex34
+    , testCase "Warning pragma without export list" ex35
     ]
 
 --------------------------------------------------------------------------------
@@ -921,6 +922,14 @@ ex34 = assertSnippet (step Nothing defaultConfig)
     , "    ( foo"
     , "    ) where"
     ]
+
+ex35 :: Assertion
+ex35 = assertSnippet (step Nothing defaultConfig) inp inp
+    where inp = [ "module X {-# WARNING \"don't use it\" #-} where"
+                , ""
+                , "foo :: Int -> Int"
+                , "foo = undefined"
+                ]
 
 openBracketSameLine :: Config -> Config
 openBracketSameLine cfg = cfg { openBracket = SameLine }

--- a/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/ModuleHeader/Tests.hs
@@ -81,6 +81,7 @@ tests = testGroup "Language.Haskell.Stylish.Printer.ModuleHeader"
     , testCase "Single one export with comment, open_bracket = same_line" ex31a
     , testCase "Single one module comment" ex32
     , testCase "Inline comments" ex33
+    , testCase "Deprecated pragma to the module" ex34
     ]
 
 --------------------------------------------------------------------------------
@@ -908,6 +909,16 @@ ex33 = assertSnippet (step Nothing $ defaultConfig)
     , "      bar -- Inline bar"
     , "      -- Foo"  -- NOTE(jaspervdj): I would prefer to have the `,` here
     , "    , foo -- Inline foo"
+    , "    ) where"
+    ]
+
+ex34 :: Assertion
+ex34 = assertSnippet (step Nothing defaultConfig)
+    [ "module X {-# DEPRECATED \"Do not use this\" #-}"
+    , "  (foo) where"
+    ]
+    [ "module X {-# DEPRECATED \"Do not use this\" #-}"
+    , "    ( foo"
     , "    ) where"
     ]
 


### PR DESCRIPTION
Fixes #433