### PR TITLE
Flip `ghc-lib` flag default to `True`

### DIFF
--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -24,7 +24,7 @@ Extra-source-files:
   data/stylish-haskell.yaml
 
 Flag ghc-lib
-  Default: False
+  Default: True
   Manual:  True
   Description:
     Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported


### PR DESCRIPTION
See https://github.com/haskell/stylish-haskell/issues/441#issuecomment-1409149858

Closes #441 (one would still have to make revisions for this to apply to already-published versions of course).