### PR TITLE
Cabal GitHub action for GHC 9.0, 9.2, 9.4

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Get the version
-      id: get_version
-      run: 'echo ::set-output name=version::${GITHUB_REF#refs/tags/}'
-
     - uses: actions/checkout@v2
 
     - uses: haskell/actions/setup@v2
@@ -27,7 +23,7 @@ jobs:
     - uses: actions/cache@v2
       name: Cache ~/.cabal
       with:
-        path: ~/.stack
+        path: ~/.cabal
         key: "${{ runner.os }}-${{ matrix.ghc }}-v9-${{ hashFiles('stylish-haskell.cabal') }}"
 
     - name: Build
@@ -36,16 +32,4 @@ jobs:
 
     - name: Test
       run: cabal test
-
-    - name: Build artifact
-      if: startsWith(github.ref, 'refs/tags')
-      run: make artifact
-      env:
-        PATAT_TAG: ${{ steps.get_version.outputs.version }}
-
-    - uses: actions/upload-artifact@v2
-      if: startsWith(github.ref, 'refs/tags')
-      with:
-        path: artifacts/*
-        name: artifacts
 

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -1,0 +1,51 @@
+name: Cabal
+
+on: ['pull_request', 'push']
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }} GHC ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        ghc: ["9.0.2", "9.2.7", "9.4.4"]
+      fail-fast: false
+
+    steps:
+    - name: Get the version
+      id: get_version
+      run: 'echo ::set-output name=version::${GITHUB_REF#refs/tags/}'
+
+    - uses: actions/checkout@v2
+
+    - uses: haskell/actions/setup@v2
+      name: Setup Haskell Cabal
+      with:
+        ghc-version: ${{ matrix.ghc }}
+
+    - uses: actions/cache@v2
+      name: Cache ~/.cabal
+      with:
+        path: ~/.stack
+        key: "${{ runner.os }}-${{ matrix.ghc }}-v9-${{ hashFiles('stylish-haskell.cabal') }}"
+
+    - name: Build
+      run: cabal build --enable-tests
+      id: build
+
+    - name: Test
+      run: cabal test
+
+    - name: Build artifact
+      if: startsWith(github.ref, 'refs/tags')
+      run: make artifact
+      env:
+        PATAT_TAG: ${{ steps.get_version.outputs.version }}
+
+    - uses: actions/upload-artifact@v2
+      if: startsWith(github.ref, 'refs/tags')
+      with:
+        path: artifacts/*
+        name: artifacts
+

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,8 @@
 
 <img src="./assets/Logo/SVG/RoundedLogo.svg" width="100px">
 
-![Build Status](https://github.com/jaspervdj/stylish-haskell/workflows/CI/badge.svg)
+![Stack Build Status](https://github.com/jaspervdj/stylish-haskell/workflows/CI/badge.svg)
+![Cabal Build Status](https://github.com/jaspervdj/stylish-haskell/workflows/Cabal/badge.svg)
 
 ## Introduction
 


### PR DESCRIPTION
separate from the current Stack GitHub Action

Build with GHC 9.2 looks good, maybe https://github.com/haskell/stylish-haskell/issues/405 can be closed

The build with GHC 9.4 fails: https://github.com/haskell/stylish-haskell/issues/449