### PR TITLE
Add `group_inverse` config option

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -324,6 +324,27 @@ steps:
       # Default: false
       group_imports: false
 
+      # Whether to invert the matches on the grouping
+      #
+      # If enabled, the group_rules will be matched in the order they are
+      # listed, then the whole list of imports is reversed.
+      #
+      # Example: having the following rules:
+      #
+      # group_rules:
+      #    - match: "^MyApp.Baz"
+      #    - match: "^MyApp"
+      #
+      # will produce the following result.
+      #
+      # > import MyApp.Foo
+      # > import MyApp.Bar
+      #
+      # > import MyApp.Baz
+      #
+      # Default: false
+      group_inverse: false
+
       # A list of rules specifying how to group modules and how to
       # order the groups.
       #

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -289,6 +289,7 @@ parseImports config o = fmap (Imports.step columns) $ Imports.Options
       <*> o A..:? "space_surround" A..!= def Imports.spaceSurround
       <*> o A..:? "post_qualify" A..!= def Imports.postQualified
       <*> o A..:? "group_imports" A..!= def Imports.groupImports
+      <*> o A..:? "group_inverse" A..!= def Imports.groupInverse
       <*> o A..:? "group_rules" A..!= def Imports.groupRules
   where
     def f = f Imports.defaultOptions


### PR DESCRIPTION
I have been experimenting with the `group_rules` but it seems POSIX ERE doesn't support negative lookahead. For my specific usecase, I need several groups that start with the same prefix and the first group has multiple suffixes, so for example:

```haskell
import Foo.Foo
import Foo.Bar

import Foo.Baz
```

I was unable to do this with the current options, but inverting the order in which the imports are written to the file, allows me to produce that with:

```yaml
group_inverse: true
group_rules:
  - match: "^Foo.Baz"
  - match: "^Foo"
```

I did this for my own benefit but I think it is nice to upstream this stuff if the core maintainers think it is useful.