### PR TITLE
Add option to remove pragmas implied by the language variant

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -426,6 +426,19 @@ steps:
       # is set to true, it will remove those redundant pragmas. Default: true.
       remove_redundant: true
 
+      # When remove_redundant is enabled, extensions that are implied by the
+      # chosen language variant will also be removed. The following language
+      # variants are supported:
+      #
+      # - GHC2021
+      #
+      # - Haskell2010
+      #
+      # - Haskell98
+      #
+      # Default: Haskell2010
+      language_variant: Haskell2010
+
       # Language prefix to be used for pragma declaration, this allows you to
       # use other options non case-sensitive like "language" or "Language".
       # If a non correct String is provided, it will default to: LANGUAGE.

--- a/lib/Language/Haskell/Stylish.hs
+++ b/lib/Language/Haskell/Stylish.hs
@@ -66,6 +66,7 @@ languagePragmas :: Maybe Int -- ^ columns
                 -> LanguagePragmas.Style
                 -> Bool -- ^ Pad to same length in vertical mode?
                 -> Bool -- ^ remove redundant?
+                -> LanguagePragmas.LanguageVariant
                 -> String -- ^ language prefix
                 -> Step
 languagePragmas = LanguagePragmas.step

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -334,6 +334,7 @@ parseLanguagePragmas config o = LanguagePragmas.step
     <*> (o A..:? "style" >>= parseEnum styles LanguagePragmas.Vertical)
     <*> o A..:? "align"            A..!= True
     <*> o A..:? "remove_redundant" A..!= True
+    <*> (o A..:? "language_variant" >>= parseEnum languageVariants LanguagePragmas.Haskell2010)
     <*> mkLanguage o
   where
     styles =
@@ -341,6 +342,11 @@ parseLanguagePragmas config o = LanguagePragmas.step
         , ("compact",          LanguagePragmas.Compact)
         , ("compact_line",     LanguagePragmas.CompactLine)
         , ("vertical_compact", LanguagePragmas.VerticalCompact)
+        ]
+    languageVariants =
+        [ ("GHC2021",     LanguagePragmas.GHC2021)
+        , ("Haskell2010", LanguagePragmas.Haskell2010)
+        , ("Haskell98",   LanguagePragmas.Haskell98)
         ]
 
 

--- a/tests/Language/Haskell/Stylish/Step/LanguagePragmas/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/LanguagePragmas/Tests.hs
@@ -33,6 +33,10 @@ tests = testGroup "Language.Haskell.Stylish.Step.LanguagePragmas.Tests"
     , testCase "case 12" case12
     , testCase "case 13" case13
     , testCase "case 14" case14
+    , testCase "case 15" case15
+    , testCase "case 16" case16
+    , testCase "case 17" case17
+    , testCase "case 18" case18
     ]
 
 lANG :: String
@@ -41,7 +45,7 @@ lANG = "LANGUAGE"
 --------------------------------------------------------------------------------
 case01 :: Assertion
 case01 = assertSnippet
-    (step (Just 80) Vertical True False lANG)
+    (step (Just 80) Vertical True False Haskell2010 lANG)
     [ "{-# LANGUAGE ViewPatterns #-}"
     , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
     , "{-# LANGUAGE ScopedTypeVariables #-}"
@@ -58,7 +62,7 @@ case01 = assertSnippet
 --------------------------------------------------------------------------------
 case02 :: Assertion
 case02 = assertSnippet
-    (step (Just 80) Vertical True True lANG)
+    (step (Just 80) Vertical True True Haskell2010 lANG)
     [ "{-# LANGUAGE BangPatterns #-}"
     , "{-# LANGUAGE ViewPatterns #-}"
     , "increment ((+ 1) -> x) = x"
@@ -72,7 +76,7 @@ case02 = assertSnippet
 --------------------------------------------------------------------------------
 case03 :: Assertion
 case03 = assertSnippet
-    (step (Just 80) Vertical True True lANG)
+    (step (Just 80) Vertical True True Haskell2010 lANG)
     [ "{-# LANGUAGE BangPatterns #-}"
     , "{-# LANGUAGE ViewPatterns #-}"
     , "increment x = case x of !_ -> x + 1"
@@ -86,7 +90,7 @@ case03 = assertSnippet
 --------------------------------------------------------------------------------
 case04 :: Assertion
 case04 = assertSnippet
-    (step (Just 80) Compact True False lANG)
+    (step (Just 80) Compact True False Haskell2010 lANG)
     [ "{-# LANGUAGE TypeOperators, StandaloneDeriving, DeriveDataTypeable,"
     , "    TemplateHaskell #-}"
     , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
@@ -101,7 +105,7 @@ case04 = assertSnippet
 --------------------------------------------------------------------------------
 case05 :: Assertion
 case05 = assertSnippet
-    (step (Just 80) Vertical True False lANG)
+    (step (Just 80) Vertical True False Haskell2010 lANG)
     [ "{-# LANGUAGE CPP #-}"
     , ""
     , "#if __GLASGOW_HASKELL__ >= 702"
@@ -120,7 +124,7 @@ case05 = assertSnippet
 --------------------------------------------------------------------------------
 case06 :: Assertion
 case06 = assertSnippet
-    (step (Just 80) CompactLine True False lANG)
+    (step (Just 80) CompactLine True False Haskell2010 lANG)
     [ "{-# LANGUAGE TypeOperators, StandaloneDeriving, DeriveDataTypeable,"
     , "    TemplateHaskell #-}"
     , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
@@ -133,7 +137,7 @@ case06 = assertSnippet
 --------------------------------------------------------------------------------
 case07 :: Assertion
 case07 = assertSnippet
-    (step (Just 80) Vertical False False lANG)
+    (step (Just 80) Vertical False False Haskell2010 lANG)
     [ "{-# LANGUAGE ViewPatterns #-}"
     , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
     , "{-# LANGUAGE ScopedTypeVariables, NoImplicitPrelude #-}"
@@ -151,7 +155,7 @@ case07 = assertSnippet
 --------------------------------------------------------------------------------
 case08 :: Assertion
 case08 = assertSnippet
-    (step (Just 80) CompactLine False False lANG)
+    (step (Just 80) CompactLine False False Haskell2010 lANG)
     [ "{-# LANGUAGE TypeOperators, StandaloneDeriving, DeriveDataTypeable,"
     , "    TemplateHaskell #-}"
     , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
@@ -165,7 +169,7 @@ case08 = assertSnippet
 --------------------------------------------------------------------------------
 case09 :: Assertion
 case09 = assertSnippet
-    (step (Just 80) Compact True False lANG)
+    (step (Just 80) Compact True False Haskell2010 lANG)
     [ "{-# LANGUAGE DefaultSignatures, FlexibleInstances, LambdaCase, " ++
       "TypeApplications"
     , "             #-}"
@@ -177,7 +181,7 @@ case09 = assertSnippet
 --------------------------------------------------------------------------------
 case10 :: Assertion
 case10 = assertSnippet
-    (step (Just 80) Compact True False lANG)
+    (step (Just 80) Compact True False Haskell2010 lANG)
     [ "{-# LANGUAGE NondecreasingIndentation, ScopedTypeVariables,"
     , "             TypeApplications #-}"
     ]
@@ -188,7 +192,7 @@ case10 = assertSnippet
 --------------------------------------------------------------------------------
 case11 :: Assertion
 case11 = assertSnippet
-    (step (Just 80) Vertical False False "language")
+    (step (Just 80) Vertical False False Haskell2010 "language")
     [ "{-# LANGUAGE ViewPatterns #-}"
     , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
     , "{-# LANGUAGE ScopedTypeVariables, NoImplicitPrelude #-}"
@@ -206,7 +210,7 @@ case11 = assertSnippet
 --------------------------------------------------------------------------------
 case12 :: Assertion
 case12 = assertSnippet
-    (step Nothing Compact False False "language")
+    (step Nothing Compact False False Haskell2010 "language")
     [ "{-# LANGUAGE ViewPatterns, OverloadedStrings #-}"
     , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
     , "{-# LANGUAGE ScopedTypeVariables, NoImplicitPrelude #-}"
@@ -221,7 +225,7 @@ case12 = assertSnippet
 --------------------------------------------------------------------------------
 case13 :: Assertion
 case13 = assertSnippet
-    (step Nothing Vertical True True lANG) input input
+    (step Nothing Vertical True True Haskell2010 lANG) input input
   where
     input =
         [ "{-# LANGUAGE BangPatterns  #-}"
@@ -231,7 +235,7 @@ case13 = assertSnippet
 
 --------------------------------------------------------------------------------
 case14 :: Assertion
-case14 = assertSnippet (step Nothing VerticalCompact False False "language")
+case14 = assertSnippet (step Nothing VerticalCompact False False Haskell2010 "language")
     [ "{-# LANGUAGE ViewPatterns, OverloadedStrings #-}"
     , "{-# LANGUAGE TemplateHaskell, ViewPatterns #-}"
     , "{-# LANGUAGE ScopedTypeVariables, NoImplicitPrelude #-}"
@@ -245,4 +249,62 @@ case14 = assertSnippet (step Nothing VerticalCompact False False "language")
     , "  , ViewPatterns"
     , "  #-}"
     , "module Main where"
+    ]
+
+--------------------------------------------------------------------------------
+case15 :: Assertion
+case15 = assertSnippet
+    (step (Just 80) Vertical False True Haskell98 lANG)
+    [ "{-# LANGUAGE DeriveGeneric #-}"
+    , "{-# LANGUAGE PatternGuards #-}"
+    , "{-# LANGUAGE StarIsType #-}"
+    , "{-# LANGUAGE TypeFamilies #-}"
+    ]
+
+    [ "{-# LANGUAGE DeriveGeneric #-}"
+    , "{-# LANGUAGE PatternGuards #-}"
+    , "{-# LANGUAGE TypeFamilies #-}"
+    ]
+
+--------------------------------------------------------------------------------
+case16 :: Assertion
+case16 = assertSnippet
+    (step (Just 80) Vertical False True Haskell2010 lANG)
+    [ "{-# LANGUAGE DeriveGeneric #-}"
+    , "{-# LANGUAGE PatternGuards #-}"
+    , "{-# LANGUAGE StarIsType #-}"
+    , "{-# LANGUAGE TypeFamilies #-}"
+    ]
+
+    [ "{-# LANGUAGE DeriveGeneric #-}"
+    , "{-# LANGUAGE TypeFamilies #-}"
+    ]
+
+--------------------------------------------------------------------------------
+case17 :: Assertion
+case17 = assertSnippet
+    (step (Just 80) Vertical False True GHC2021 lANG)
+    [ "{-# LANGUAGE DeriveGeneric #-}"
+    , "{-# LANGUAGE PatternGuards #-}"
+    , "{-# LANGUAGE StarIsType #-}"
+    , "{-# LANGUAGE TypeFamilies #-}"
+    ]
+
+    [ "{-# LANGUAGE TypeFamilies #-}"
+    ]
+
+--------------------------------------------------------------------------------
+case18 :: Assertion
+case18 = assertSnippet
+    (step (Just 80) Vertical False False GHC2021 lANG)
+    [ "{-# LANGUAGE DeriveGeneric #-}"
+    , "{-# LANGUAGE PatternGuards #-}"
+    , "{-# LANGUAGE StarIsType #-}"
+    , "{-# LANGUAGE TypeFamilies #-}"
+    ]
+
+    [ "{-# LANGUAGE DeriveGeneric #-}"
+    , "{-# LANGUAGE PatternGuards #-}"
+    , "{-# LANGUAGE StarIsType #-}"
+    , "{-# LANGUAGE TypeFamilies #-}"
     ]


### PR DESCRIPTION
For example, by setting `language_variant` to `GHC2021`, all the extensions implied by the GHC2021 language variant will be removed as redundant language pragmas.