### PR TITLE
Rename constructors and related parser strings of LongListAlign

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+- Unreleased
+     * #467 Rename constructors of LongListAlign to better reflect implmentatnion (by sorki)
+       * InlineToBreak is now InlineToNewline
+       * InlineToMultiline is now InlineToNewlineToMultiline
+
 - 0.14.5.0 (2023-06-23)
      * #459 Support GHC 9.6 (By Michael Peyton Jones)
      * #445 Default `ghc-lib` flag to True (by amesgen)

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -200,14 +200,26 @@ steps:
       #
       # - inline: This option will put as much specs on same line as possible.
       #
-      # - new_line: Import list will start on new line.
+      # - new_line: Import list will start on new line when it wouldn't fit
+      #   to single line. (deprecated, renamed to inline_to_new_line)
       #
-      # - new_line_multiline: Import list will start on new line when it's
-      #   short enough to fit to single line. Otherwise it'll be multiline.
+      # - inline_to_new_line: Import list will start on new line when it
+      #   wouldn't fit to single line.
       #
-      # - multiline: One line per import list entry.
+      # - new_line_multiline: Import list will be put inline if it fits
+      #   or put on new line when it's short enough to fit to single
+      #   line. Otherwise it'll be multiline.
+      #   (deprecated, renamed to inline_to_new_line_to_multiline)
+      #
+      # - inline_to_new_line_to_multiline: Import list will be put inline if
+      #   it fits or put on new line when it's short enough to fit to single
+      #   line. Otherwise it'll be multiline.
+      #
+      # - multiline: Inline if import list is short enough to fit, otherwise
+      #   one line per import list entry.
       #   Type with constructor list acts like single import.
       #
+      #   > import Data.Map (Map)
       #   > import qualified Data.Map as M
       #   >     ( empty
       #   >     , singleton

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -311,10 +311,14 @@ parseImports config o = fmap (Imports.step columns) $ Imports.Options
         ]
 
     longListAligns =
-        [ ("inline",             Imports.Inline)
-        , ("new_line",           Imports.InlineWithBreak)
-        , ("new_line_multiline", Imports.InlineToMultiline)
-        , ("multiline",          Imports.Multiline)
+        [ ("inline",                          Imports.Inline)
+        , ("new_line",                        Imports.InlineToNewline)
+        -- ^ deprecated
+        , ("inline_to_new_line",              Imports.InlineToNewline)
+        , ("new_line_multiline",              Imports.InlineToNewlineToMultiline)
+        -- ^ deprecated
+        , ("inline_to_new_line_to_multiline", Imports.InlineToNewlineToMultiline)
+        , ("multiline",                       Imports.Multiline)
         ]
 
     emptyListAligns =

--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -120,8 +120,8 @@ data EmptyListAlign
 
 data LongListAlign
     = Inline -- inline
-    | InlineWithBreak -- new_line
-    | InlineToMultiline -- new_line_multiline
+    | InlineToNewline -- inline_to_new_line (or deprecated new_line)
+    | InlineToNewlineToMultiline -- inline_to_new_line_to_multiline (or deprecated new_line_multiline)
     | Multiline -- multiline
     deriving (Eq, Show)
 
@@ -483,12 +483,12 @@ printQualified Options{..} padNames stats ldecl = do
                 modifyCurrentLine trimRight
                 newline >> putOffset >> printAsInlineWrapping (putText wrapPrefix)
               Inline -> space >> printAsInlineWrapping (putText wrapPrefix)
-              InlineWithBreak -> wrapping
+              InlineToNewline -> wrapping
                 (space >> printAsSingleLine)
                 (do
                   modifyCurrentLine trimRight
                   newline >> putOffset >> printAsInlineWrapping putOffset)
-              InlineToMultiline -> wrapping
+              InlineToNewlineToMultiline -> wrapping
                 (space >> printAsSingleLine)
                 (wrapping
                   (do

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -420,7 +420,7 @@ case13 =
     options = defaultOptions
       { importAlign   = None
       , listAlign     = WithAlias
-      , longListAlign = InlineWithBreak
+      , longListAlign = InlineToNewline
       }
   in
     assertSnippet (step (Just 80) options)
@@ -438,7 +438,7 @@ case13b =
     options = defaultOptions
       { importAlign   = None
       , listAlign     = WithModuleName
-      , longListAlign = InlineWithBreak
+      , longListAlign = InlineToNewline
       }
   in
     assertSnippet (step (Just 80) options)
@@ -458,7 +458,7 @@ case14 =
     options = defaultOptions
       { importAlign   = None
       , listAlign     = WithAlias
-      , longListAlign = InlineWithBreak
+      , longListAlign = InlineToNewline
       , listPadding   = LPConstant 10
       }
   in
@@ -542,7 +542,7 @@ case17 =
 case18 :: Assertion
 case18 =
   let
-    options = defaultOptions { importAlign = None, longListAlign = InlineToMultiline }
+    options = defaultOptions { importAlign = None, longListAlign = InlineToNewlineToMultiline }
   in
     assertSnippet (step (Just 40) options)
     [ "import Data.Foo as Foo (Bar, Baz, Foo)"
@@ -571,7 +571,7 @@ case19 =
   let
     options = defaultOptions
       { listAlign      = NewLine
-      , longListAlign  = InlineWithBreak
+      , longListAlign  = InlineToNewline
       , emptyListAlign = RightAfter
       , listPadding    = LPConstant 17
       }
@@ -593,7 +593,7 @@ case19b =
     options = defaultOptions
       { importAlign    = File
       , listAlign      = NewLine
-      , longListAlign  = InlineWithBreak
+      , longListAlign  = InlineToNewline
       , emptyListAlign = RightAfter
       , listPadding    = LPConstant 17
       }
@@ -614,7 +614,7 @@ case19c =
     options = defaultOptions
       { importAlign    = File
       , listAlign      = NewLine
-      , longListAlign  = InlineWithBreak
+      , longListAlign  = InlineToNewline
       , emptyListAlign = RightAfter
       , listPadding    = LPModuleName
       }
@@ -634,7 +634,7 @@ case19d =
   let
     options = defaultOptions
       { listAlign      = NewLine
-      , longListAlign  = InlineWithBreak
+      , longListAlign  = InlineToNewline
       , emptyListAlign = RightAfter
       , listPadding    = LPModuleName
       }
@@ -792,7 +792,7 @@ case24 =
     options = defaultOptions
       { importAlign    = None
       , padModuleNames = False
-      , longListAlign  = InlineWithBreak
+      , longListAlign  = InlineToNewline
       , spaceSurround  = True
       }
   in


### PR DESCRIPTION
The documentation of these doesn't quite reflect the implementation and it seems to cause some confusion.

This patch tries to address it by renaming `LongListAlign` constructors to better reflect what they do and fix their documentation in `stylish-haskell.yaml`.

There is no change in functionality but it introduces a breaking change for users using the Haskell interface. It also adds a (lousy) concept of config option deprecation in form of documenting the deprecated variants in favor of new names.

Related to #462