### PR TITLE
Add MultilineOnly LostListAlign variant

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- Unreleased
+     * #468 Add MultilineOnly LongListAlign variant (by sorki)
+
 - 0.14.5.0 (2023-06-23)
      * #459 Support GHC 9.6 (By Michael Peyton Jones)
      * #445 Default `ghc-lib` flag to True (by amesgen)

--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -215,6 +215,8 @@ steps:
       #   >     , delete
       #   >     )
       #
+      # - multiline_only: One line per import entry.
+      #
       # Default: inline
       long_list_align: inline
 

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -315,6 +315,7 @@ parseImports config o = fmap (Imports.step columns) $ Imports.Options
         , ("new_line",           Imports.InlineWithBreak)
         , ("new_line_multiline", Imports.InlineToMultiline)
         , ("multiline",          Imports.Multiline)
+        , ("multiline_only",     Imports.MultilineOnly)
         ]
 
     emptyListAligns =

--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -123,6 +123,7 @@ data LongListAlign
     | InlineWithBreak -- new_line
     | InlineToMultiline -- new_line_multiline
     | Multiline -- multiline
+    | MultilineOnly -- multiline_only
     deriving (Eq, Show)
 
 -- | A rule for grouping imports that specifies which module names
@@ -479,6 +480,7 @@ printQualified Options{..} padNames stats ldecl = do
               Multiline -> wrapping
                 (space >> printAsSingleLine)
                 printAsMultiLine
+              MultilineOnly -> printAsMultiLine
               Inline | NewLine <- listAlign -> do
                 modifyCurrentLine trimRight
                 newline >> putOffset >> printAsInlineWrapping (putText wrapPrefix)

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -47,6 +47,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Imports.Tests"
     , testCase "case 16" case16
     , testCase "case 17" case17
     , testCase "case 18" case18
+    , testCase "case 18b" case18b
     , testCase "case 19" case19
     , testCase "case 19b" case19b
     , testCase "case 19d" case19c
@@ -556,6 +557,36 @@ case18 =
     , ""
     , "import Data.Identity"
     , "    (Identity (Identity, runIdentity))"
+    , ""
+    , "import Data.Acid as Acid"
+    , "    ( closeAcidState"
+    , "    , createCheckpoint"
+    , "    , openLocalStateFrom"
+    , "    )"
+    ]
+
+case18b :: Assertion
+case18b =
+  let
+    options = defaultOptions { importAlign = None, longListAlign = MultilineOnly }
+  in
+    assertSnippet (step (Just 40) options)
+    [ "import Data.Foo as Foo (Bar, Baz, Foo)"
+    , ""
+    , "import Data.Identity (Identity (Identity, runIdentity))"
+    , ""
+    , "import Data.Acid as Acid (closeAcidState, createCheckpoint, openLocalStateFrom)"
+    ]
+       ----------------------------------------
+    [ "import Data.Foo as Foo"
+    , "    ( Bar"
+    , "    , Baz"
+    , "    , Foo"
+    , "    )"
+    , ""
+    , "import Data.Identity"
+    , "    ( Identity (Identity, runIdentity)"
+    , "    )"
     , ""
     , "import Data.Acid as Acid"
     , "    ( closeAcidState"


### PR DESCRIPTION
Adding `MultlineOnly` mode which forces multiline output without trying inline first. Related to #467 