### PR TITLE
Add EntityListAlign to imports step

### DIFF
--- a/data/stylish-haskell.yaml
+++ b/data/stylish-haskell.yaml
@@ -218,6 +218,29 @@ steps:
       # Default: inline
       long_list_align: inline
 
+      # Entity list align can be used to alter alignment of import list entities
+      # like 'Bar' record names in the following example:
+      #
+      #   > import Foo (Bar(x, y))
+      #
+      # - inline: Entities are always formatted inline
+      #
+      # - multiline: The list of entities will start on new line,
+      #   except for a case, when it cotains only a single entity.
+      #
+      #   > import Foo
+      #   >     (Bar
+      #   >         ( x
+      #   >         , y
+      #   >         )
+      #   >     )
+      #
+      #   This is useful in combination with long_list_aling multiline
+      #   and similar to get a git friendly formatting.
+      #
+      # Default: inline
+      entity_list_align: inline
+
       # Align empty list (importing instances)
       #
       # Empty list align has following options

--- a/lib/Language/Haskell/Stylish/Config.hs
+++ b/lib/Language/Haskell/Stylish/Config.hs
@@ -283,6 +283,7 @@ parseImports config o = fmap (Imports.step columns) $ Imports.Options
       <*> (o A..:? "pad_module_names" A..!= def Imports.padModuleNames)
       <*> (o A..:? "long_list_align" >>= parseEnum longListAligns (def Imports.longListAlign))
       <*> (o A..:? "empty_list_align" >>= parseEnum emptyListAligns (def Imports.emptyListAlign))
+      <*> (o A..:? "entity_list_align" >>= parseEnum entityListAligns (def Imports.entityListAlign))
       -- Note that padding has to be at least 1. Default is 4.
       <*> (o A..:? "list_padding" >>= maybe (pure $ def Imports.listPadding) parseListPadding)
       <*> o A..:? "separate_lists" A..!= def Imports.separateLists
@@ -320,6 +321,11 @@ parseImports config o = fmap (Imports.step columns) $ Imports.Options
     emptyListAligns =
         [ ("inherit", Imports.Inherit)
         , ("right_after", Imports.RightAfter)
+        ]
+
+    entityListAligns =
+        [ ("inline", Imports.ELInline)
+        , ("multiline", Imports.ELMultiline)
         ]
 
     parseListPadding = \case

--- a/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
+++ b/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
@@ -226,4 +226,7 @@ printMultiLineExportList conf exports = do
 -- NOTE(jaspervdj): This code is almost the same as the import printing in
 -- 'Imports' and should be merged.
 putExport :: Config -> GHC.LIE GHC.GhcPs -> P ()
-putExport conf = Imports.printImport (separateLists conf) . GHC.unLoc
+putExport conf =
+  Imports.printImport
+    (Imports.defaultOptions { Imports.separateLists = separateLists conf})
+  . GHC.unLoc

--- a/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Imports/Tests.hs
@@ -79,6 +79,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Imports.Tests"
     , testCase "case 44a" case44a
     , testCase "case 44b" case44b
     , testCase "case 44c" case44c
+    , testCase "case 45" case45
     ]
 
 
@@ -1291,3 +1292,22 @@ case44c =
               ]
           , importAlign  = None
           }
+
+
+--------------------------------------------------------------------------------
+case45 :: Assertion
+case45 =
+  let
+    options = defaultOptions { importAlign = None, entityListAlign = ELMultiline }
+  in
+    assertSnippet (step (Just 40) options)
+    case45input
+    [ "import Foo (Bar"
+    , "          ( x"
+    , "          , y"
+    , "          ))"
+    ]
+
+case45input :: Snippet
+case45input =
+    [ "import Foo (Bar(x, y))" ]


### PR DESCRIPTION
This patch add support for alignment of lists of constructors, class methods, fields names in import lists entities.

`ELMultiline` causes

```
import Foo (Bar(x, y))
```

To be expanded to

```
import Foo
  (Bar
    ( x
    , y
    )
  )
```

This is useful in combination with `LongListAlign` `Multiline` to get a git friendly formatting.