### PR TITLE
Don't drop type from type data (TypeData)

### DIFF
--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -521,7 +521,10 @@ putType' cfg lty = case GHC.unLoc lty of
     _ -> putType lty
 
 newOrData :: DataDecl -> String
-newOrData decl = if isNewtype decl then "newtype" else "data"
+newOrData decl
+  | isNewtype decl  = "newtype"
+  | isTypeData decl = "type data"
+  | otherwise       = "data"
 
 isGADT :: DataDecl -> Bool
 isGADT = any isGADTCons . GHC.dd_cons . dataDefn
@@ -532,6 +535,9 @@ isGADT = any isGADTCons . GHC.dd_cons . dataDefn
 
 isNewtype :: DataDecl -> Bool
 isNewtype = (== GHC.NewType) . GHC.dataDefnConsNewOrData . GHC.dd_cons . dataDefn
+
+isTypeData :: DataDecl -> Bool
+isTypeData = GHC.isTypeDataDefnCons . GHC.dd_cons . dataDefn
 
 isInfix :: DataDecl -> Bool
 isInfix = (== GHC.Infix) . dataFixity

--- a/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
+++ b/tests/Language/Haskell/Stylish/Step/Data/Tests.hs
@@ -79,6 +79,7 @@ tests = testGroup "Language.Haskell.Stylish.Step.Data.Tests"
     , testCase "case 64" case64
     , testCase "case 65" case65
     , testCase "case 66 (issue #411)" case66
+    , testCase "case 67" case67
     ]
 
 case00 :: Assertion
@@ -1379,6 +1380,14 @@ case66 = assertSnippet (step indentIndentStyle) input input
     input =
       [ "data Foo = A | B | C"
       , "  deriving (Eq, Show)"
+      ]
+
+-- | Don't drop type from type data (TypeData)
+case67 :: Assertion
+case67 = assertSnippet (step indentIndentStyle) input input
+  where
+    input =
+      [ "type data Foo = A | B | C"
       ]
 
 sameSameStyle :: Config


### PR DESCRIPTION
Alongside `newtype` and `data`, GHC 9.6 introduced `type data`.