### PR TITLE
[feature] stylish-haskell as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: stylish-haskell
+    name: haskell code prettifier
+    description: A haskell code prettifier.
+    entry: stylish-haskell
+    language: haskell
+    types: [haskell]
+    args: [-i]


### PR DESCRIPTION
Hello,
i've tried to add pre-commit support for users of stylish-haskell.

You can test it, by
- cloning my fork locally 
- create a a new folder e.g. `Example` outside the `stylish-haskell` repo
    - `cd Example`
    - `git init`
    - add mail and name to git
    - copy `example/Bad.hs` from the stylish-haskell repo to your folder `Example`
    - `git add Bad.hs`
    - `git commit -m "initial commit"`
    - `pre-commit try-repo  your/local/path/to/repo/stylish-haskell/ --all-files`
        - execute it twice, as it will fail the first time
- `Bad.hs` should be formatted now

Be aware that the `try-repo` command of `pre-commit` works with HEAD of the local stylish-haskell repo, so commit your changes of `.pre-commit-hooks.yaml`.
The `--all-files` argument ensures that your `Bad.hs` is not skipped (and that's the reason why I don't use the command in `stylish-haskell/examples`, as it would change every `.hs` file in the repo).

Pre-commit uses `cabal` to install stylish-haskell. I've tested this with ghc 9.8.2 and 
cabal 3.10.3.0.

People should be able to use now `stylish-haskell` in pre-commit by adding this to their `.pre-commit-config.yaml` and running `pre-commit run --all-files` or committing in their haskell project repo.
```yaml
repos:
-   repo: https://github.com/haskell/stylish-haskell.git
# main for the rev:  section is possible, but `pre-commit` will complain
    rev: release/X.Y.Z
    hooks:
    -   id: stylish-haskell
```

Thank you
Greetings
LucBro