### PR TITLE
Upgrade to ghc 9.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        ghc: ["9.6.6", "9.8", "9.10"]
+        ghc: ["9.10", "9.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/lib/Language/Haskell/Stylish/Comments.hs
+++ b/lib/Language/Haskell/Stylish/Comments.hs
@@ -61,7 +61,7 @@ commentGroups getSpan allItems allComments =
     commentsWithLines :: [(LineBlock, GHC.LEpaComment)]
     commentsWithLines = do
         comment <- allComments
-        let s = GHC.anchor $ GHC.getLoc comment
+        let s = GHC.epaLocationRealSrcSpan $ GHC.getLoc comment
         pure (realSrcSpanToLineBlock s, comment)
 
     work

--- a/lib/Language/Haskell/Stylish/Config/Cabal.hs
+++ b/lib/Language/Haskell/Stylish/Config/Cabal.hs
@@ -53,7 +53,7 @@ findCabalFile verbose configSearchStrategy = case configSearchStrategy of
   go searched (p : ps) = do
 
 #if MIN_VERSION_Cabal(3,14,0)
-    let projectRoot = Just $ makeSymbolicPath p
+    let projectRoot = Just $ Cabal.makeSymbolicPath p
     potentialCabalFile <- Cabal.findPackageDesc projectRoot
 #else
     potentialCabalFile <- Cabal.findPackageDesc p

--- a/lib/Language/Haskell/Stylish/GHC.hs
+++ b/lib/Language/Haskell/Stylish/GHC.hs
@@ -86,6 +86,6 @@ deepAnnComments :: (Data a, Typeable a) => a -> [GHC.LEpaComment]
 deepAnnComments = everything (++) (mkQ [] priorAndFollowing)
 
 priorAndFollowing :: GHC.EpAnnComments -> [GHC.LEpaComment]
-priorAndFollowing = sortOn (GHC.anchor . GHC.getLoc) . \case
+priorAndFollowing = sortOn (GHC.epaLocationRealSrcSpan . GHC.getLoc) . \case
     GHC.EpaComments         {..} -> priorComments
     GHC.EpaCommentsBalanced {..} -> priorComments ++ followingComments

--- a/lib/Language/Haskell/Stylish/Module.hs
+++ b/lib/Language/Haskell/Stylish/Module.hs
@@ -141,7 +141,7 @@ moduleLanguagePragmas =
     prag comment = case GHC.ac_tok (GHC.unLoc comment) of
         GHC.EpaBlockComment str
             | lang : p1 : ps <- tokenize str, map toLower lang == "language" ->
-                pure (GHC.anchor (GHC.getLoc comment), p1 :| ps)
+                pure (GHC.epaLocationRealSrcSpan (GHC.getLoc comment), p1 :| ps)
         _ -> Nothing
 
     tokenize = words .

--- a/lib/Language/Haskell/Stylish/Step/Data.hs
+++ b/lib/Language/Haskell/Stylish/Step/Data.hs
@@ -103,6 +103,8 @@ step cfg = makeStep "Data" \ls m -> Editor.apply (changes m) ls
         isAfterStart :: GHC.LEpaComment -> Bool
         isAfterStart (GHC.L (GHC.EpaSpan (GHC.RealSrcSpan commentSpan _)) _) =
                GHC.srcSpanStartLine commentSpan >= GHC.srcSpanStartLine declSpan
+        isAfterStart (GHC.L (GHC.EpaDelta (GHC.RealSrcSpan commentSpan _) _ _) _) =
+               GHC.srcSpanStartLine commentSpan >= GHC.srcSpanStartLine declSpan
         isAfterStart _ = False
 
     dataDecls :: Module -> [DataDecl]

--- a/lib/Language/Haskell/Stylish/Step/Imports.hs
+++ b/lib/Language/Haskell/Stylish/Step/Imports.hs
@@ -638,7 +638,7 @@ prepareImportList =
   prepareInner :: GHC.IE GHC.GhcPs -> GHC.IE GHC.GhcPs
   prepareInner = \case
     -- Simplify `A ()` to `A`.
-    GHC.IEThingWith x n GHC.NoIEWildcard [] md -> GHC.IEThingAbs x n md
+    GHC.IEThingWith x n GHC.NoIEWildcard [] md -> GHC.IEThingAbs (fst x) n md
     GHC.IEThingWith x n w ns md ->
       GHC.IEThingWith x n w (sortBy (compareWrappedName `on` GHC.unLoc) ns) md
     ie -> ie

--- a/lib/Language/Haskell/Stylish/Step/LanguagePragmas.hs
+++ b/lib/Language/Haskell/Stylish/Step/LanguagePragmas.hs
@@ -198,5 +198,5 @@ isRedundantBangPatterns modul =
 
     getMatchStrict :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> [()]
     getMatchStrict (GHC.Match _ ctx _ _) = case ctx of
-      GHC.FunRhs _ _ GHC.SrcStrict -> [()]
-      _                            -> []
+      GHC.FunRhs _ _ GHC.SrcStrict _ -> [()]
+      _                              -> []

--- a/lib/Language/Haskell/Stylish/Step/SimpleAlign.hs
+++ b/lib/Language/Haskell/Stylish/Step/SimpleAlign.hs
@@ -112,7 +112,7 @@ matchGroupToAlignable conf mg = cases' ++ patterns'
 matchToAlignable
     :: GHC.LocatedA (Hs.Match Hs.GhcPs (Hs.LHsExpr Hs.GhcPs))
     -> Maybe (Either (Alignable GHC.RealSrcSpan) (Alignable GHC.RealSrcSpan))
-matchToAlignable (GHC.L matchLoc m@(Hs.Match _ Hs.CaseAlt pats@(_ : _) grhss)) = do
+matchToAlignable (GHC.L matchLoc m@(Hs.Match _ Hs.CaseAlt (GHC.L _ pats@(_ : _)) grhss)) = do
   let patsLocs   = map GHC.getLocA pats
       pat        = last patsLocs
       guards     = getGuards m
@@ -128,7 +128,7 @@ matchToAlignable (GHC.L matchLoc m@(Hs.Match _ Hs.CaseAlt pats@(_ : _) grhss)) =
     , aRight     = rightPos
     , aRightLead = length "-> "
     }
-matchToAlignable (GHC.L matchLoc (Hs.Match _ (Hs.FunRhs name _ _) pats@(_ : _) grhss)) = do
+matchToAlignable (GHC.L matchLoc (Hs.Match _ (Hs.FunRhs name _ _ _) (GHC.L _ pats@(_ : _)) grhss)) = do
   body <- unguardedRhsBody grhss
   let patsLocs = map GHC.getLocA pats
       nameLoc  = GHC.getLocA name

--- a/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
+++ b/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
@@ -24,7 +24,7 @@ hsTyReplacements (GHC.HsFunTy _ arr _ _)
         Editor.replaceRealSrcSpan (GHC.epaLocationRealSrcSpan epaLoc) "→"
 hsTyReplacements (GHC.HsQualTy _ ctx _)
     | Just arrow <- GHC.ac_darrow . GHC.anns $ GHC.getLoc ctx
-    , (GHC.NormalSyntax, GHC.EpaSpan (GHC.RealSrcSpan loc _)) <- arrow =
+    , (GHC.EpUniTok (GHC.EpaSpan (GHC.RealSrcSpan loc _)) GHC.NormalSyntax) <- arrow =
         Editor.replaceRealSrcSpan loc "⇒"
 hsTyReplacements _ = mempty
 
@@ -32,7 +32,7 @@ hsTyReplacements _ = mempty
 --------------------------------------------------------------------------------
 hsSigReplacements :: GHC.Sig GHC.GhcPs -> Editor.Edits
 hsSigReplacements (GHC.TypeSig ann _ _)
-    | GHC.AddEpAnn GHC.AnnDcolon epaLoc <- GHC.asDcolon ann
+    | GHC.EpUniTok epaLoc _ <- GHC.asDcolon ann
     , GHC.EpaSpan (GHC.RealSrcSpan loc _) <- epaLoc =
         Editor.replaceRealSrcSpan loc "∷"
 hsSigReplacements _ = mempty

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -37,7 +37,7 @@ Common depends
 
   Build-depends:
     aeson             >= 0.6    && < 2.3,
-    base              >= 4.8    && < 5,
+    base              >= 4.19    && < 5,
     bytestring        >= 0.9    && < 0.13,
     Cabal             >= 3.14   && < 4.0,
     containers        >= 0.3    && < 0.9,
@@ -59,17 +59,17 @@ Common depends
   -- and we have a new enough GHC. Note that
   -- this will only work if the user's
   -- compiler is of the matching major version!
-  if !flag(ghc-lib) && impl(ghc >= 9.8) && impl(ghc < 9.11)
+  if !flag(ghc-lib) && impl(ghc >= 9.8) && impl(ghc < 9.13)
     Build-depends:
-      ghc >= 9.10 && < 9.11,
+      ghc >= 9.12 && < 9.13,
       ghc-boot,
       ghc-boot-th
   else
     Build-depends:
-      ghc-lib-parser >= 9.10 && < 9.11
+      ghc-lib-parser >= 9.12 && < 9.13
 
   Build-depends:
-    ghc-lib-parser-ex >= 9.10 && < 9.11
+    ghc-lib-parser-ex >= 9.12 && < 9.13
 
 Library
   Import:         depends


### PR DESCRIPTION
Building on #480, this makes stylish-haskell functionally complete for ghc-9.12. Only one failing test left.